### PR TITLE
feat: Save audio type on download

### DIFF
--- a/AmpFinKit/Sources/AFBase/Models/Track.swift
+++ b/AmpFinKit/Sources/AFBase/Models/Track.swift
@@ -102,12 +102,12 @@ extension Track {
     
     public struct ReducedAlbum: Codable {
         public let id: String
-        public let name: String?
+        public let albumName: String?
         public let artists: [ReducedArtist]
         
         public init(id: String, name: String?, artists: [ReducedArtist]) {
             self.id = id
-            self.name = name
+            self.albumName = name
             self.artists = artists
         }
     }

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftData
 import AFBase
 
 extension DownloadManager {
@@ -14,12 +15,22 @@ extension DownloadManager {
             URLQueryItem(name: "api_key", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
-            URLQueryItem(name: "container", value: "mp3,aac,flac,alac,webma,webm|webma,wav,aiff,aiff|aif"),
+            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif"),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),
-            URLQueryItem(name: "transcodingContainer", value: "aac"),
+            URLQueryItem(name: "transcodingContainer", value: "m4a"),
             URLQueryItem(name: "transcodingProtocol", value: "http"),
         ])))
+    }
+    
+    func getTrackFileType(trackId: String) -> String? {
+        var descriptor = FetchDescriptor<OfflineTrack>(predicate: #Predicate { $0.id == trackId })
+        descriptor.fetchLimit = 1
+        let ctx = ModelContext(PersistenceManager.shared.modelContainer)
+        if let track = try? ctx.fetch(descriptor).first {
+            return track.fileType
+        }
+        return nil
     }
     
     func delete(trackId: String) {
@@ -27,8 +38,35 @@ extension DownloadManager {
     }
     
     public func getUrl(trackId: String) -> URL {
+        getUrlWithType(trackId: trackId, fileType: getTrackFileType(trackId: trackId))
+    }
+    
+    public func getUrlWithType(trackId: String, fileType: String?) -> URL {
+        var suffix: String
+        switch fileType {
+        case "audio/aac":
+            suffix = ".aac"
+        // Both alac and aac can be in this container
+        case "audio/mp4":
+            suffix = ".m4a"
+        case "audio/flac":
+            suffix = ".flac"
+        case "audio/x-flac":
+            suffix = ".flac"
+        case "audio/mpeg":
+            suffix = ".mp3"
+        case "audio/wav":
+            suffix = ".wav"
+        case "audio/x-aiff":
+            suffix = ".aiff"
+        case "audio/webm":
+            suffix = ".webma"
+        // Use flac if unsure
+        default:
+            suffix = ".flac"
+        }
         // the audio player refuses to play anything without an extension. but it can be wrong...
-        documentsURL.appending(path: "tracks").appending(path: "\(trackId).flac")
+        return documentsURL.appending(path: "tracks").appending(path: "\(trackId)\(suffix)")
     }
 }
 

--- a/AmpFinKit/Sources/AFOffline/Items/Convert/Track+Convert.swift
+++ b/AmpFinKit/Sources/AFOffline/Items/Convert/Track+Convert.swift
@@ -17,7 +17,7 @@ extension Track {
             favorite: offline.favorite,
             album: ReducedAlbum(
                 id: offline.album.id,
-                name: offline.album.name,
+                name: offline.album.albumName,
                 artists: offline.album.artists),
             artists: offline.artists,
             lufs: nil,
@@ -35,7 +35,7 @@ extension Track {
             favorite: offline.favorite,
             album: ReducedAlbum(
                 id: offline.album.id,
-                name: offline.album.name,
+                name: offline.album.albumName,
                 artists: offline.album.artists),
             artists: offline.artists,
             lufs: nil,

--- a/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
+++ b/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
@@ -23,8 +23,9 @@ class OfflineTrack {
     var runtime: Double
     
     var downloadId: Int?
+    var fileType: String? = nil
     
-    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil) {
+    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil, fileType: String? = nil) {
         self.id = id
         self.name = name
         self.album = album
@@ -32,6 +33,7 @@ class OfflineTrack {
         self.artists = artists
         self.favorite = favorite
         self.downloadId = downloadId
+        self.fileType = fileType
         self.runtime = runtime
     }
 }

--- a/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
+++ b/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
@@ -10,7 +10,7 @@ import SwiftData
 import AFBase
 
 @Model
-class OfflineTrack {
+final class OfflineTrack {
     @Attribute(.unique) let id: String
     let name: String
     
@@ -23,7 +23,7 @@ class OfflineTrack {
     var runtime: Double
     
     var downloadId: Int?
-    var fileType: String? = nil
+    var fileType: String?
     
     init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil, fileType: String? = nil) {
         self.id = id

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Metadata.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Metadata.swift
@@ -16,7 +16,7 @@ internal extension LocalAudioEndpoint {
                 
                 nowPlayingInfo[MPMediaItemPropertyTitle] = nowPlaying.name
                 nowPlayingInfo[MPMediaItemPropertyArtist] = nowPlaying.artistName
-                nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = nowPlaying.album.name
+                nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = nowPlaying.album.albumName
                 nowPlayingInfo[MPMediaItemPropertyAlbumArtist] = nowPlaying.album.artistName
                 
                 // nowPlayingInfo[MPMediaItemPropertyPersistentID] = nowPlaying.id

--- a/AmpFinKit/Sources/AFPlayback/RemoteAudioEndpoint/RemoteAudioEndpoint.swift
+++ b/AmpFinKit/Sources/AFPlayback/RemoteAudioEndpoint/RemoteAudioEndpoint.swift
@@ -113,7 +113,7 @@ extension RemoteAudioEndpoint {
             
             nowPlayingInfo[MPMediaItemPropertyTitle] = nowPlaying.name
             nowPlayingInfo[MPMediaItemPropertyArtist] = nowPlaying.artistName
-            nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = nowPlaying.album.name
+            nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = nowPlaying.album.albumName
             nowPlayingInfo[MPMediaItemPropertyAlbumArtist] = nowPlaying.album.artistName
             nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = duration
             nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime

--- a/Siri Extension/Shared/MediaResolver.swift
+++ b/Siri Extension/Shared/MediaResolver.swift
@@ -41,7 +41,7 @@ extension MediaResolver {
         tracks.filter {
             var matches = true
             
-            if let albumName = albumName, let name = $0.album.name {
+            if let albumName = albumName, let name = $0.album.albumName {
                 if !name.localizedStandardContains(albumName) {
                     matches = false
                 }

--- a/iOS/Presentation/Components/Items/Tracks/TrackList.swift
+++ b/iOS/Presentation/Components/Items/Tracks/TrackList.swift
@@ -120,7 +120,7 @@ extension TrackList {
         var tracks = tracks
         
         if search != "" {
-            tracks = tracks.filter { $0.name.lowercased().contains(search.lowercased()) || ($0.album.name?.lowercased() ?? "").contains(search.lowercased()) }
+            tracks = tracks.filter { $0.name.lowercased().contains(search.lowercased()) || ($0.album.albumName?.lowercased() ?? "").contains(search.lowercased()) }
         }
         
         if album != nil {

--- a/iOS/Presentation/Components/Items/Tracks/TrackListRow.swift
+++ b/iOS/Presentation/Components/Items/Tracks/TrackListRow.swift
@@ -204,7 +204,7 @@ extension TrackListRow {
                 NavigationLink(destination: AlbumLoadView(albumId: track.album.id)) {
                     Label("album.view", systemImage: "square.stack")
                     
-                    if let name = track.album.name {
+                    if let name = track.album.albumName {
                         Text(verbatim: name)
                     }
                 }

--- a/iOS/Presentation/Components/NowPlaying/NowPlayingBar+ContextMenu.swift
+++ b/iOS/Presentation/Components/NowPlaying/NowPlayingBar+ContextMenu.swift
@@ -53,7 +53,7 @@ extension NowPlayingBarModifier {
                     }) {
                         Label("album.view", systemImage: "square.stack")
                         
-                        if let albumName = track.album.name {
+                        if let albumName = track.album.albumName {
                             Text(albumName)
                         }
                     }

--- a/iOS/Presentation/Components/NowPlaying/NowPlayingView+Title.swift
+++ b/iOS/Presentation/Components/NowPlaying/NowPlayingView+Title.swift
@@ -131,7 +131,7 @@ extension NowPlayingViewModifier {
                 }) {
                     Label("album.view", systemImage: "square.stack")
                     
-                    if let albumName = track.album.name {
+                    if let albumName = track.album.albumName {
                         Text(albumName)
                     }
                 }

--- a/iOS/Utility/Intents/SpotlightHelper.swift
+++ b/iOS/Utility/Intents/SpotlightHelper.swift
@@ -35,9 +35,9 @@ struct SpotlightHelper {
                     let attributes = CSSearchableItemAttributeSet(contentType: .audio)
                     
                     attributes.title = track.name
-                    attributes.album = track.album.name
+                    attributes.album = track.album.albumName
                     attributes.artist = track.artists.map { $0.name }.joined(separator: ", ")
-                    attributes.album = track.album.name
+                    attributes.album = track.album.albumName
                     
                     attributes.duration = NSNumber(value: track.runtime)
                     attributes.playCount = track.playCount as NSNumber

--- a/iOS/Utility/LibraryDataProviders/OfflineLibraryDataProvider.swift
+++ b/iOS/Utility/LibraryDataProviders/OfflineLibraryDataProvider.swift
@@ -20,7 +20,7 @@ public struct OfflineLibraryDataProvider: LibraryDataProvider {
             case .name:
                 return $0.name < $1.name
             case .album:
-                return $0.album.name ?? "?" < $1.album.name ?? "?"
+                return $0.album.albumName ?? "?" < $1.album.albumName ?? "?"
             case .albumArtist:
                 return $0.album.artists.first?.name ?? "?" < $1.album.artists.first?.name ?? "?"
             case .artist:


### PR DESCRIPTION
This will save file mime-type on download into the offlineTrack model, and infer the file url from that key.

To keep backward compatibility it will use flac when this key is missing which is the same as the old behavior, so that media is playable in the old version will continue to work.

To workaround a SwiftData migration bug, it renamed the ReducedAlbum's `name` key to `albumName`, because SwiftData will attempt to create two `ZNAME` column if we don't rename this. Ask Apple for why, but to make it work we have to perform such rename for now.

This also contains a small fix for the container matching. For aiff, it should be `aiff,aif`, and not `aiff, aif|aiff` as the aiff encoding is treated as PCM on server, so we only need to match the container not the encoding.