### PR TITLE
feat: Save audio type on download v2

### DIFF
--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Handler.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Handler.swift
@@ -23,13 +23,13 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         
         Task.detached { @MainActor [self] in
             if let track = try? OfflineManager.shared.getOfflineTrack(taskId: downloadTask.taskIdentifier) {
-                let destination = getUrlWithType(trackId: track.id, fileType: mimeType)
+                let typeCode = encodeFileType(fileType: mimeType)
+                let destination = getUrlWithType(trackId: track.id, typeCode: typeCode)
                 
                 do {
                     try? FileManager.default.removeItem(at: destination)
                     try FileManager.default.moveItem(at: tmpLocation, to: destination)
-                    track.downloadId = nil
-                    track.fileType = mimeType
+                    track.downloadId = typeCode
                     
                     NotificationCenter.default.post(name: OfflineManager.itemDownloadStatusChanged, object: track.id)
                     

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -23,12 +23,12 @@ extension DownloadManager {
         ])))
     }
     
-    func getTrackFileType(trackId: String) -> String? {
+    func getTrackFileType(trackId: String) -> Int? {
         var descriptor = FetchDescriptor<OfflineTrack>(predicate: #Predicate { $0.id == trackId })
         descriptor.fetchLimit = 1
         let ctx = ModelContext(PersistenceManager.shared.modelContainer)
         if let track = try? ctx.fetch(descriptor).first {
-            return track.fileType
+            return track.downloadId
         }
         return nil
     }
@@ -38,28 +38,53 @@ extension DownloadManager {
     }
     
     public func getUrl(trackId: String) -> URL {
-        getUrlWithType(trackId: trackId, fileType: getTrackFileType(trackId: trackId))
+        getUrlWithType(trackId: trackId, typeCode: getTrackFileType(trackId: trackId))
     }
     
-    public func getUrlWithType(trackId: String, fileType: String?) -> URL {
-        var suffix: String
+    public func encodeFileType(fileType: String?) -> Int {
+        var code = -1;
         switch fileType {
+        case "audio/flac":
+            code = -1
         case "audio/aac":
-            suffix = ".aac"
+            code = -2
         // Both alac and aac can be in this container
         case "audio/mp4":
-            suffix = ".m4a"
-        case "audio/flac":
-            suffix = ".flac"
+            code = -3
         case "audio/x-flac":
-            suffix = ".flac"
+            code = -1
         case "audio/mpeg":
-            suffix = ".mp3"
+            code = -4
         case "audio/wav":
-            suffix = ".wav"
+            code = -5
         case "audio/x-aiff":
-            suffix = ".aiff"
+            code = -6
         case "audio/webm":
+            code = -7
+        // Use flac if unsure
+        default:
+            code = -1
+        }
+        return code
+    }
+    
+    public func getUrlWithType(trackId: String, typeCode: Int?) -> URL {
+        var suffix: String
+        switch typeCode {
+        case -1:
+            suffix = ".flac"
+        case -2:
+            suffix = ".aac"
+        // Both alac and aac can be in this container
+        case -3:
+            suffix = ".m4a"
+        case -4:
+            suffix = ".mp3"
+        case -5:
+            suffix = ".wav"
+        case -6:
+            suffix = ".aiff"
+        case -7:
             suffix = ".webma"
         // Use flac if unsure
         default:

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftData
 import AFBase
 
 extension DownloadManager {
@@ -14,12 +15,22 @@ extension DownloadManager {
             URLQueryItem(name: "api_key", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
-            URLQueryItem(name: "container", value: "mp3,aac,flac,alac,webma,webm|webma,wav,aiff,aiff|aif"),
+            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif"),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),
-            URLQueryItem(name: "transcodingContainer", value: "aac"),
+            URLQueryItem(name: "transcodingContainer", value: "m4a"),
             URLQueryItem(name: "transcodingProtocol", value: "http"),
         ])))
+    }
+    
+    func getTrackFileType(trackId: String) -> String? {
+        var descriptor = FetchDescriptor<OfflineTrack>(predicate: #Predicate { $0.id == trackId })
+        descriptor.fetchLimit = 1
+        let ctx = ModelContext(PersistenceManager.shared.modelContainer)
+        if let track = try? ctx.fetch(descriptor).first {
+            return track.fileType
+        }
+        return nil
     }
     
     func delete(trackId: String) {
@@ -27,8 +38,35 @@ extension DownloadManager {
     }
     
     public func getUrl(trackId: String) -> URL {
+        getUrlWithType(trackId: trackId, fileType: getTrackFileType(trackId: trackId))
+    }
+    
+    public func getUrlWithType(trackId: String, fileType: String?) -> URL {
+        var suffix: String
+        switch fileType {
+        case "audio/aac":
+            suffix = ".aac"
+        // Both alac and aac can be in this container
+        case "audio/mp4":
+            suffix = ".m4a"
+        case "audio/flac":
+            suffix = ".flac"
+        case "audio/x-flac":
+            suffix = ".flac"
+        case "audio/mpeg":
+            suffix = ".mp3"
+        case "audio/wav":
+            suffix = ".wav"
+        case "audio/x-aiff":
+            suffix = ".aiff"
+        case "audio/webm":
+            suffix = ".webma"
+        // Use flac if unsure
+        default:
+            suffix = ".flac"
+        }
         // the audio player refuses to play anything without an extension. but it can be wrong...
-        documentsURL.appending(path: "tracks").appending(path: "\(trackId).flac")
+        return documentsURL.appending(path: "tracks").appending(path: "\(trackId)\(suffix)")
     }
 }
 

--- a/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
+++ b/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
@@ -23,8 +23,9 @@ class OfflineTrack {
     var runtime: Double
     
     var downloadId: Int?
+    var fileType: String? = nil
     
-    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil) {
+    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil, fileType: String? = nil) {
         self.id = id
         self.name = name
         self.album = album
@@ -32,6 +33,7 @@ class OfflineTrack {
         self.artists = artists
         self.favorite = favorite
         self.downloadId = downloadId
+        self.fileType = fileType
         self.runtime = runtime
     }
 }

--- a/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
+++ b/AmpFinKit/Sources/AFOffline/Models/OfflineTrack.swift
@@ -23,9 +23,8 @@ class OfflineTrack {
     var runtime: Double
     
     var downloadId: Int?
-    var fileType: String? = nil
     
-    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil, fileType: String? = nil) {
+    init(id: String, name: String, releaseDate: Date?, album: Track.ReducedAlbum, artists: [Item.ReducedArtist], favorite: Bool, runtime: Double, downloadId: Int? = nil) {
         self.id = id
         self.name = name
         self.album = album
@@ -33,7 +32,6 @@ class OfflineTrack {
         self.artists = artists
         self.favorite = favorite
         self.downloadId = downloadId
-        self.fileType = fileType
         self.runtime = runtime
     }
 }

--- a/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Parent.swift
+++ b/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Parent.swift
@@ -38,7 +38,7 @@ extension OfflineManager {
     @MainActor
     func isDownloadInProgress(parent: OfflineParent) throws -> Bool {
         let tracks = try getOfflineTracks(parent: parent)
-        return tracks.reduce(false) { $1.downloadId == nil ? $0 : true }
+        return tracks.reduce(false) { $1.downloadId ?? -1 < 0 ? $0 : true }
     }
     
     func reduceToChildrenIds(parents: [OfflineParent]) -> Set<String> {

--- a/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Track.swift
@@ -83,7 +83,7 @@ extension OfflineManager {
     
     @MainActor
     func getUnfinishedDownloads() throws -> [OfflineTrack] {
-        let track = FetchDescriptor<OfflineTrack>(predicate: #Predicate { $0.downloadId != nil })
+        let track = FetchDescriptor<OfflineTrack>(predicate: #Predicate { $0.downloadId ?? -1 > 0 })
         return try PersistenceManager.shared.modelContainer.mainContext.fetch(track)
     }
 }
@@ -131,7 +131,7 @@ public extension OfflineManager {
     @MainActor
     func getOfflineStatus(trackId: String) -> ItemOfflineTracker.OfflineStatus {
         if let track = try? getOfflineTrack(trackId: trackId) {
-            return track.downloadId == nil ? .downloaded : .working
+            return track.downloadId ?? -1 < 0 ? .downloaded : .working
         }
         
         return .none


### PR DESCRIPTION
This will save file mime-type and encode it into a negative number, and then encode it into the `downloadId` key of the `OfflineTrack`.  When this key is nil, it defaults to `-1`, which corresponds to `flac` to match the old behavior, and the item downloaded in an older version can still be played.

I really don't want to resort to something like this, but the problem is out of my control, and I believe it's a SwiftData issue. I'm concerned that any further changes to the Data-schema for the Persistence Manager will be impossible until Apple fixes this migration issue. I can't even complete the migration by removing everything from the old context. However, for our current use case, this solution will work, as the `downloadId` provided by URLSession is never negative, and we have a finite number of file types to support.