### PR TITLE
fix: don't use UIScreen for iPad

### DIFF
--- a/Multiplatform/Navigation/Regular/SidebarView.swift
+++ b/Multiplatform/Navigation/Regular/SidebarView.swift
@@ -22,6 +22,7 @@ struct SidebarView: View {
                 PlaylistSection()
             }
             .modifier(AccountToolbarButtonModifier(requiredSize: nil))
+            .modifier(NowPlayingBarLeadingOffsetModifier())
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {

--- a/Multiplatform/NowPlaying/Compact/CompactNowPlayingBarModifier.swift
+++ b/Multiplatform/NowPlaying/Compact/CompactNowPlayingBarModifier.swift
@@ -84,7 +84,7 @@ struct CompactNowPlayingBarModifier: ViewModifier {
                                 }
                                 .imageScale(.large)
                             }
-                            .frame(width: UIScreen.main.bounds.width - 32, height: 56)
+                            .frame(height: 56)
                             .padding(.horizontal, 8)
                             .foregroundStyle(.primary)
                             .background {
@@ -100,6 +100,7 @@ struct CompactNowPlayingBarModifier: ViewModifier {
                             .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
                             .shadow(color: .black.opacity(0.25), radius: 20)
                             .padding(.bottom, 10)
+                            .padding(.horizontal, 12)
                             .zIndex(1)
                             .onTapGesture {
                                 nowPlayingViewState.setNowPlayingViewPresented(true)

--- a/Multiplatform/NowPlaying/Compact/CompactNowPlayingViewModifier.swift
+++ b/Multiplatform/NowPlaying/Compact/CompactNowPlayingViewModifier.swift
@@ -48,6 +48,12 @@ struct CompactNowPlayingViewModifier: ViewModifier {
                             insertion: .modifier(active: BackgroundInsertTransitionModifier(active: true), identity: BackgroundInsertTransitionModifier(active: false)),
                             removal: .modifier(active: BackgroundRemoveTransitionModifier(active: true), identity: BackgroundRemoveTransitionModifier(active: false)))
                         )
+                        .onAppear {
+                            // In rare cases, this value is not set to 0 on closing.
+                            // Forcing a reset to 0 on appearance to prevent strange animations
+                            // where the container appears halfway on the screen.
+                            dragOffset = 0
+                        }
                 }
                 
                 if viewState.containerPresented {
@@ -140,7 +146,6 @@ struct CompactNowPlayingViewModifier: ViewModifier {
             .allowsHitTesting(presentedTrack != nil)
             // This is very reasonable and sane
             .padding(.top, UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }?.safeAreaInsets.top)
-            .frame(height: UIScreen.main.bounds.height)
             .offset(y: dragOffset)
             .animation(.spring, value: dragOffset)
         }
@@ -159,7 +164,8 @@ struct BackgroundInsertTransitionModifier: ViewModifier {
         content
             .mask(alignment: .bottom) {
                 Rectangle()
-                    .frame(width: UIScreen.main.bounds.width - (active ? 24 : 0), height: active ? 0 : UIScreen.main.bounds.height)
+                    .frame(maxHeight: active ? 0 : .infinity)
+                    .padding(.horizontal, active ? 12 : 0)
             }
             .offset(y: active ? -146 : 0)
     }
@@ -175,7 +181,8 @@ struct BackgroundRemoveTransitionModifier: ViewModifier {
         content
             .mask(alignment: .bottom) {
                 Rectangle()
-                    .frame(width: UIScreen.main.bounds.width - (active ? 24 : 0), height: active ? 0 : UIScreen.main.bounds.height)
+                    .frame(maxHeight: active ? 0 : .infinity)
+                    .padding(.horizontal, active ? 12 : 0)
                     .animation(Animation.smooth, value: active)
             }
             .offset(y: active ? -92 : 0)

--- a/Multiplatform/NowPlaying/Modifier/NowPlayingBarSafeAreaModifier.swift
+++ b/Multiplatform/NowPlaying/Modifier/NowPlayingBarSafeAreaModifier.swift
@@ -9,6 +9,30 @@ import Foundation
 import SwiftUI
 import AFPlayback
 
+// This thing is very funny, we will need this due to how Apple implemented NavigationSplitView.
+// The NavigationSplitView is implemented with a wrapper around UIKit, so not a SwiftUI native component.
+// A SwiftUI way to determine if we need the offset to make space for the sidebar is to monitor the binded
+// value columnVisibility of the NavigationSplitView, but since this is a UIKit wrapped component, this value
+// changes AFTER the view change has been commited, which means when the size of the view changes and triggers
+// SwiftUI update, this value will not change until all animations are done. The onDisappear trigger also has
+// similar problem, so we have to use our old friend GeometryReader to actually read the origin and pass the x
+// value as our offset.
+struct NowPlayingBarLeadingOffsetModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack {
+            GeometryReader { reader in
+                Color.clear
+                    .onChange(of: reader.frame(in: .global).origin) {
+                        NotificationCenter.default.post(name: .init("b"), object: reader.frame(in: .global).origin.x)
+                        print(reader.frame(in: .global).origin)
+                    }
+            }
+            .frame(height: 0)
+            content
+        }
+    }
+}
+
 struct NowPlayingBarSafeAreaModifier: ViewModifier {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
@@ -21,8 +45,11 @@ struct NowPlayingBarSafeAreaModifier: ViewModifier {
             content
                 .safeAreaPadding(.bottom, isVisible ? 75 : 0)
         } else {
-            // this piece of shit is required because some apple engineer though it would be funny if a
-            // navigation stack inside a split view detail section would do absolutely fucking nothing
+            // We need this because the modifier will only be applied to the root view of the NavigationStack, and
+            // to add the NowPlayingBarModifier to each and every view in the stack maually is just horrible.
+            // Also we can only embeded a NavigationSplitView inside a TabView but not the other way around.
+            // This makes the the SwiftUI way of size negotialtion almost impossible.
+            // Use GeometryReader is the only reliable way to determine the max width for our floating player.
             // https://forums.developer.apple.com/forums/thread/735672
             // https://stackoverflow.com/questions/76167468/strange-navigation-with-navigationstack-inside-navigationsplitview
             ZStack {

--- a/Multiplatform/NowPlaying/Modifier/NowPlayingBarSafeAreaModifier.swift
+++ b/Multiplatform/NowPlaying/Modifier/NowPlayingBarSafeAreaModifier.swift
@@ -24,7 +24,6 @@ struct NowPlayingBarLeadingOffsetModifier: ViewModifier {
                 Color.clear
                     .onChange(of: reader.frame(in: .global).origin) {
                         NotificationCenter.default.post(name: .init("b"), object: reader.frame(in: .global).origin.x)
-                        print(reader.frame(in: .global).origin)
                     }
             }
             .frame(height: 0)

--- a/Multiplatform/NowPlaying/NowPlayingBackground.swift
+++ b/Multiplatform/NowPlaying/NowPlayingBackground.swift
@@ -11,19 +11,9 @@ import FluidGradient
 import AFBase
 
 struct NowPlayingBackground: View {
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
     let cover: Item.Cover?
     
     @State private var imageColors: ImageColors?
-    
-    private var size: CGFloat {
-        if horizontalSizeClass == .compact {
-            return 1000
-        } else {
-            return 2000
-        }
-    }
     
     var body: some View {
         ZStack {
@@ -32,11 +22,11 @@ struct NowPlayingBackground: View {
             ItemImage(cover: cover)
                 .id(cover?.url)
                 .blur(radius: 100)
-                .frame(width: size, height: size)
+                .frame(maxWidth: .infinity)
             
             if let imageColors = imageColors {
                 FluidGradient(blobs: [imageColors.background, imageColors.detail, imageColors.primary, imageColors.secondary], speed: CGFloat.random(in: 0.2...0.4), blur: 0.8)
-                    .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height + 100)
+                    .ignoresSafeArea(edges: .all)
                     .onChange(of: cover?.url) { determineImageColors() }
             } else {
                 Color.clear
@@ -44,7 +34,7 @@ struct NowPlayingBackground: View {
             }
         }
         .overlay(.black.opacity(0.25))
-        .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        .ignoresSafeArea(edges: .all)
         .allowsHitTesting(false)
     }
     

--- a/Multiplatform/NowPlaying/NowPlayingButtons.swift
+++ b/Multiplatform/NowPlaying/NowPlayingButtons.swift
@@ -113,7 +113,7 @@ struct NowPlayingButtons: View {
         .bold()
         .font(.system(size: 20))
         .frame(height: 45)
-        .padding(.top, 35)
+        .padding(.top, horizontalSizeClass == .regular ? 0 : 35)
     }
     
     func setActiveTab(_ tab: NowPlayingTab) {

--- a/Multiplatform/NowPlaying/NowPlayingControls.swift
+++ b/Multiplatform/NowPlaying/NowPlayingControls.swift
@@ -19,8 +19,14 @@ struct NowPlayingControls: View {
     @State private var volumeDragging = false
     @State private var draggedPercentage = 0.0
     
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    
     private var playedPercentage: Double {
         (AudioPlayer.current.currentTime / AudioPlayer.current.duration) * 100
+    }
+    
+    private var useHorizontalLayout: Bool {
+               return horizontalSizeClass == .regular
     }
     
     var body: some View {
@@ -36,7 +42,7 @@ struct NowPlayingControls: View {
                         controlsDragging = $0
                     }))
                 .frame(height: 10)
-                .padding(.bottom, 10)
+                .padding(.bottom, useHorizontalLayout ? 3 : 10)
                 
                 HStack {
                     Group {
@@ -55,8 +61,8 @@ struct NowPlayingControls: View {
                         Text(quality)
                             .font(.caption2)
                             .foregroundStyle(.primary)
-                            .padding(.vertical, 4)
-                            .padding(.horizontal, 8)
+                            .padding(.vertical, useHorizontalLayout ? 1 : 4)
+                            .padding(.horizontal, useHorizontalLayout ? 10 : 8)
                             .background(.tertiary)
                             .clipShape(RoundedRectangle(cornerRadius: 3))
                     }
@@ -77,12 +83,13 @@ struct NowPlayingControls: View {
                         }
                     } label: {
                         Image(systemName: "backward.fill")
+                            .font(.system(size: 30))
                     }
                     Button {
                         AudioPlayer.current.playing = !AudioPlayer.current.playing
                     } label: {
                         Image(systemName: AudioPlayer.current.playing ? "pause.fill" : "play.fill")
-                            .frame(height: 50)
+                            .frame(width: 50, height:50)
                             .font(.system(size: 47))
                             .padding(.horizontal, 50)
                             .contentTransition(.symbolEffect(.replace))
@@ -93,13 +100,14 @@ struct NowPlayingControls: View {
                         }
                     } label: {
                         Image(systemName: "forward.fill")
+                            .font(.system(size: 30))
                     }
                 }
-                .font(.system(size: 34))
+                //.font(.system(size: 34))
                 .foregroundStyle(.primary)
             }
-            .padding(.top, 35)
-            .padding(.bottom, 65)
+            .padding(.top, useHorizontalLayout ? 20 : 35)
+            .padding(.bottom, useHorizontalLayout ? 40 : 65)
             
             // The first view is the visible slider, the second one is there to hide the iOS indicator (10/10 hack)
             VolumeSlider(dragging: .init(get: { volumeDragging }, set: {

--- a/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
+++ b/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
@@ -137,9 +137,9 @@ struct RegularNowPlayingBarModifier: ViewModifier {
                         }
                     }
                     .padding(.horizontal, 25)
-                    .padding(.leading, adjust)
                     .fullScreenCover(isPresented: $sheetPresented) {
                         RegularNowPlayingView()
+                            .ignoresSafeArea(edges: .all)
                     }
                 }
             }

--- a/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
+++ b/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
@@ -137,6 +137,9 @@ struct RegularNowPlayingBarModifier: ViewModifier {
                         }
                     }
                     .padding(.horizontal, 25)
+                    .padding(.leading, adjust)
+                    .animation(.spring, value: width)
+                    .animation(.spring, value: adjust)
                     .fullScreenCover(isPresented: $sheetPresented) {
                         RegularNowPlayingView()
                             .ignoresSafeArea(edges: .all)
@@ -145,10 +148,12 @@ struct RegularNowPlayingBarModifier: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .init("a"))) { notification in
                 if let width = notification.object as? CGFloat {
-                    withAnimation(.spring) {
-                        self.width = min(width, 1100)
-                        adjust = UIScreen.main.bounds.width - width
-                    }
+                    self.width = min(width, 1100)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .init("b"))) { notification in
+                if let offset = notification.object as? CGFloat {
+                    adjust = 320 + offset
                 }
             }
     }

--- a/Multiplatform/NowPlaying/Regular/RegularNowPlayingView.swift
+++ b/Multiplatform/NowPlaying/Regular/RegularNowPlayingView.swift
@@ -19,9 +19,7 @@ struct RegularNowPlayingView: View {
     var body: some View {
         ZStack {
             if let track = AudioPlayer.current.nowPlaying {
-                // i hate this so much? why is it of? just why
                 NowPlayingBackground(cover: track.cover)
-                    .frame(height: UIScreen.main.bounds.height + 5)
                     .clipped()
                 
                 VStack {
@@ -32,7 +30,8 @@ struct RegularNowPlayingView: View {
                             NowPlayingCover(track: track, currentTab: currentTab, namespace: namespace)
                             NowPlayingControls(controlsDragging: $controlsDragging)
                         }
-                        .frame(width: 500)
+                        .frame(maxWidth: 415)
+                        .padding(.horizontal)
                         
                         Spacer()
                         
@@ -47,7 +46,7 @@ struct RegularNowPlayingView: View {
                                 }
                                 .transition(.blurReplace)
                             }
-                            .frame(width: UIScreen.main.bounds.width / 2)
+                            .padding(.leading)
                             .padding(.trailing, 30)
                             .transition(.move(edge: .trailing))
                         }
@@ -60,6 +59,7 @@ struct RegularNowPlayingView: View {
                 }
                 .padding(.bottom)
                 .padding(.top, 75)
+                .ignoresSafeArea(edges: .all)
                 .foregroundStyle(.white)
                 .simultaneousGesture(
                     DragGesture(minimumDistance: 25, coordinateSpace: .global)


### PR DESCRIPTION
Most of the statically calculated frame sizes can be omitted, allowing SwiftUI to negotiate them by itself.

The most interesting part is handling the `NavigationSplitView` and our `NowPlayingBar`.

Firstly, all modifiers will only apply to the root view in the `NavigationStack`, which is not suitable for the `NowPlayingBar` unless we want to manually add this thing to each and every view in the stack.

Secondly, the `NavigationSplitView` is wrapped around UIKit and is not SwiftUI native. This means its state change will occur after the view change, causing issues because we want to know if the sidebar is visible or not to calculate the padding for the `NowPlayingBar`. However, that status will not change until all animations are finished. Instead, we have to observe the origin of the sidebar and use that position to calculate the padding.