### PR TITLE
fix: add mac catalyst specific workarounds

### DIFF
--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
@@ -68,7 +68,7 @@ internal extension LocalAudioEndpoint {
             paused: !playing,
             repeatMode: repeatMode,
             shuffled: shuffled,
-            volume: audioSession.outputVolume,
+            volume: volume,
             scheduled: scheduled)
     }
     

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint.swift
@@ -67,12 +67,18 @@ internal class LocalAudioEndpoint: AudioEndpoint {
     
     public var volume: Float {
         get {
+#if targetEnvironment(macCatalyst)
+            audioPlayer.volume
+#else
             audioSession.outputVolume
+#endif
         }
         set {
-            #if os(iOS)
+#if targetEnvironment(macCatalyst)
+            audioPlayer.volume = newValue
+#else
             MPVolumeView.setVolume(newValue)
-            #endif
+#endif
         }
     }
     

--- a/Multiplatform/Account/AccountSheet.swift
+++ b/Multiplatform/Account/AccountSheet.swift
@@ -15,7 +15,7 @@ struct AccountSheet: View {
     @State private var username: String?
     @State private var sessions: [Session]? = nil
     @State private var downloads: [Track]? = nil
-    @Binding var accountSheetPresented: Bool
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         List {
@@ -182,7 +182,7 @@ struct AccountSheet: View {
             } catch {}
         }
 #if targetEnvironment(macCatalyst)
-        Button(action: { accountSheetPresented = false }) {
+        Button(action: { dismiss() }) {
             Text("Close")
                 .padding(.vertical)
                 .frame(maxWidth: .infinity)
@@ -214,7 +214,7 @@ struct AccountToolbarButtonModifier: ViewModifier {
                     }
                 }
                 .sheet(isPresented: $accountSheetPresented) {
-                    AccountSheet(accountSheetPresented: $accountSheetPresented)
+                    AccountSheet()
                 }
         } else {
             content
@@ -226,6 +226,6 @@ struct AccountToolbarButtonModifier: ViewModifier {
 #Preview {
     Text(verbatim: ":)")
         .sheet(isPresented: .constant(true)) {
-            AccountSheet(accountSheetPresented: .constant(true))
+            AccountSheet()
         }
 }

--- a/Multiplatform/Account/AccountSheet.swift
+++ b/Multiplatform/Account/AccountSheet.swift
@@ -15,6 +15,7 @@ struct AccountSheet: View {
     @State private var username: String?
     @State private var sessions: [Session]? = nil
     @State private var downloads: [Track]? = nil
+    @Binding var accountSheetPresented: Bool
     
     var body: some View {
         List {
@@ -180,6 +181,16 @@ struct AccountSheet: View {
                 (username, _, _, _) = try await JellyfinClient.shared.getUserData()
             } catch {}
         }
+#if targetEnvironment(macCatalyst)
+        Button(action: { accountSheetPresented = false }) {
+            Text("Close")
+                .padding(.vertical)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(Color.white)
+                .background(Color.accentColor)
+        }
+        .padding(.top, -10)
+#endif
     }
 }
 
@@ -203,7 +214,7 @@ struct AccountToolbarButtonModifier: ViewModifier {
                     }
                 }
                 .sheet(isPresented: $accountSheetPresented) {
-                    AccountSheet()
+                    AccountSheet(accountSheetPresented: $accountSheetPresented)
                 }
         } else {
             content
@@ -215,6 +226,6 @@ struct AccountToolbarButtonModifier: ViewModifier {
 #Preview {
     Text(verbatim: ":)")
         .sheet(isPresented: .constant(true)) {
-            AccountSheet()
+            AccountSheet(accountSheetPresented: .constant(true))
         }
 }

--- a/Multiplatform/Album/AlbumView+Toolbar.swift
+++ b/Multiplatform/Album/AlbumView+Toolbar.swift
@@ -11,7 +11,8 @@ import AFOffline
 
 extension AlbumView {
     struct ToolbarModifier: ViewModifier {
-        @Environment(\.presentationMode) private var presentationMode
+        @Environment(\.isPresented) private var isPresented
+        @Environment(\.dismiss) private var dismiss
         @Environment(\.libraryDataProvider) private var dataProvider
         @Environment(\.libraryOnline) private var libraryOnline
         
@@ -59,9 +60,9 @@ extension AlbumView {
                 }
                 .toolbar {
                     ToolbarItem(placement: .navigation) {
-                        if !toolbarBackgroundVisible && presentationMode.wrappedValue.isPresented {
+                        if !toolbarBackgroundVisible && isPresented {
                             Button {
-                                presentationMode.wrappedValue.dismiss()
+                                dismiss()
                             } label: {
                                 Image(systemName: "chevron.left")
                                     .modifier(FullscreenToolbarModifier(imageColors: imageColors, toolbarBackgroundVisible: toolbarBackgroundVisible))

--- a/Multiplatform/Core/iOSApp.swift
+++ b/Multiplatform/Core/iOSApp.swift
@@ -29,9 +29,10 @@ struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+#if targetEnvironment(macCatalyst)
+                .onAppear { (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.titlebar?.titleVisibility = .hidden }
+#endif
         }
         .modelContainer(PersistenceManager.shared.modelContainer)
-        // why does this not work? because
-        // .windowStyle(HiddenTitleBarWindowStyle())
     }
 }

--- a/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
+++ b/Multiplatform/NowPlaying/Regular/RegularNowPlayingBarModifier.swift
@@ -153,7 +153,7 @@ struct RegularNowPlayingBarModifier: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .init("b"))) { notification in
                 if let offset = notification.object as? CGFloat {
-                    adjust = 320 + offset
+                    adjust = offset
                 }
             }
     }


### PR DESCRIPTION
The Mac Catalyst target has some behavioral differences due to UIKit being replaced by AppKit in some instances. Additionally, it has different conventions for controls, such as the volume control. On iOS, the volume control is expected to be system-wide, but on macOS, it is expected to be app-specific. To match the iOS App's appearance, the titlebar also needs to be hidden, but this cannot be done with SwiftUI and has to use UIKit methods which is weird. 

This PR addressed most outstanding issues I found during my usage, but there could be more. If you found more feel free to tell me and I'm going to look at them.