### PR TITLE
feat: make spotlight work with large libraries

### DIFF
--- a/AmpFinKit/Sources/AFBase/Extensions/Item/Cover+Convert.swift
+++ b/AmpFinKit/Sources/AFBase/Extensions/Item/Cover+Convert.swift
@@ -9,9 +9,9 @@ import Foundation
 
 extension Item.Cover {
     /// Parse the image from a Jellyfin item
-    static func convertFromJellyfin(imageTags: JellyfinClient.ImageTags, id: String) -> Item.Cover? {
+    static func convertFromJellyfin(imageTags: JellyfinClient.ImageTags, id: String, useLowRes: Bool = false) -> Item.Cover? {
         if let primaryImageTag = imageTags.Primary {
-            return Item.Cover(type: .remote, url: constructItemCoverUrl(itemId: id, imageTag: primaryImageTag))
+            return Item.Cover(type: .remote, url: constructItemCoverUrl(itemId: id, imageTag: primaryImageTag, size: useLowRes ? 125 : 800))
         }
         
         return nil

--- a/AmpFinKit/Sources/AFBase/Extensions/Item/Track+Convert.swift
+++ b/AmpFinKit/Sources/AFBase/Extensions/Item/Track+Convert.swift
@@ -9,15 +9,15 @@ import Foundation
 
 extension Track {
     /// Convert an item received from the Jellyfin server into a track type
-    static func convertFromJellyfin(_ item: JellyfinClient.JellyfinTrackItem, fallbackIndex: Int = 0) throws -> Track {
+    static func convertFromJellyfin(_ item: JellyfinClient.JellyfinTrackItem, fallbackIndex: Int = 0, useLowResCover: Bool = false) throws -> Track {
         guard let albumId = item.AlbumId else { throw JellyfinClientError.invalidResponse }
         
         var cover: Item.Cover?
         
         if item.ImageTags.Primary != nil {
-            cover = Cover.convertFromJellyfin(imageTags: item.ImageTags, id: item.Id)
+            cover = Cover.convertFromJellyfin(imageTags: item.ImageTags, id: item.Id, useLowRes: useLowResCover)
         } else if let imageTag = item.AlbumPrimaryImageTag {
-            cover = Cover.convertFromJellyfin(imageTags: JellyfinClient.ImageTags.init(Primary: imageTag), id: albumId)
+            cover = Cover.convertFromJellyfin(imageTags: JellyfinClient.ImageTags.init(Primary: imageTag), id: albumId, useLowRes: useLowResCover)
         }
         
         return Track(

--- a/AmpFinKit/Sources/AFBase/HTTP/Methods/JellyfinClient+Tracks.swift
+++ b/AmpFinKit/Sources/AFBase/HTTP/Methods/JellyfinClient+Tracks.swift
@@ -16,7 +16,7 @@ public extension JellyfinClient {
     // MARK: Get Tracks
     
     /// Get all tracks from all libraries and albums
-    func getTracks(limit: Int, startIndex: Int, sortOrder: ItemSortOrder, ascending: Bool, favorite: Bool, search: String?) async throws -> ([Track], Int) {
+    func getTracks(limit: Int, startIndex: Int, sortOrder: ItemSortOrder, ascending: Bool, favorite: Bool, search: String?, useLowResCover: Bool = false) async throws -> ([Track], Int) {
         var query = [
             URLQueryItem(name: "SortBy", value: sortOrder.rawValue),
             URLQueryItem(name: "SortOrder", value: ascending ? "Ascending" : "Descending"),
@@ -43,7 +43,7 @@ public extension JellyfinClient {
         let response = try await request(ClientRequest<TracksItemResponse>(path: "Items", method: "GET", query: query, userPrefix: true))
         
         return (
-            response.Items.enumerated().compactMap { try? Track.convertFromJellyfin($1, fallbackIndex: $0) },
+            response.Items.enumerated().compactMap { try? Track.convertFromJellyfin($1, fallbackIndex: $0, useLowResCover: useLowResCover) },
             response.TotalRecordCount
         )
     }

--- a/Multiplatform/Utility/Extensions/Defaults+Keys.swift
+++ b/Multiplatform/Utility/Extensions/Defaults+Keys.swift
@@ -20,4 +20,5 @@ extension Defaults.Keys {
     
     static let spotlightDisabled = Key("spotlightDisabled", default: false)
     static let lastSpotlightDonation = Key<Double>("lastSpotlightDonation", default: 0)
+    static let lastSpotlightDonationCompletion = Key<Double>("lastSpotlightDonationCompletion", default: 0)
 }


### PR DESCRIPTION
This will batch the indexing with 250 items a time, and have confirmed with the backend developers that this is a safe number. Also reduced the cover size for indexing, as the spotlight does not need full size image which consumes more bandwidth and storage. This implementation can also resume from an incomplete indexing, in case a long indexing is interrupted.