### PR TITLE
feat: save audio file type v4

### DIFF
--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Handler.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Handler.swift
@@ -34,7 +34,9 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             }
             
             var values = URLResourceValues()
-            var destination = self.url(trackId: track.id)
+            let mimeType = downloadTask.response?.mimeType
+            setTrackFileType(track: track, mimeType: mimeType)
+            var destination = url(track: track)
             
             values.isExcludedFromBackup = true
             try? destination.setResourceValues(values)


### PR DESCRIPTION
This conforms to the latest data structure and tested that both files downloaded before and after this can be played.

One problem I found during the testing: in sidebar mode the player always defaults to online source even when I navigated to the offline version of the page. I have to cut the internet connection entirely to make it load the offline track.