### PR TITLE
fix: too high volume on macOS catalyst

### DIFF
--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Playback.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Playback.swift
@@ -129,7 +129,11 @@ internal extension LocalAudioEndpoint {
             #if os(iOS) && !targetEnvironment(macCatalyst)
             AVAudioSession.sharedInstance().outputVolume
             #else
-            audioPlayer.volume
+            // Why, Apple. The valid range is float from 0.0 to 1.0, and you will return 100
+            if (audioPlayer.volume > 1) {
+                audioPlayer.volume = 1.0
+            }
+            return audioPlayer.volume
             #endif
         }
         set {


### PR DESCRIPTION
For some reason this value could be 100 which is beyond valid range, and on macOS this will cause the volume being excessively high. Overwrite it to 1.0 when detected