### PR TITLE
Set playSessionId to control cache behavior

### DIFF
--- a/AmpFinKit/Sources/AFFoundation/Utility/Session.swift
+++ b/AmpFinKit/Sources/AFFoundation/Utility/Session.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 
 @Observable
 public final class Session: Identifiable, Codable {
@@ -94,5 +95,15 @@ public final class Session: Identifiable, Codable {
         try container.encode(self.shuffled, forKey: .shuffled)
     }
     
+}
+
+public extension Session {
+    static func getSessionId(profileString: String) -> String {
+        let digest = Insecure.MD5.hash(data: Data(profileString.utf8))
+
+        return digest.map {
+            String(format: "%02hhx", $0)
+        }.joined()
+    }
 }
 

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+Progress.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+Progress.swift
@@ -34,10 +34,14 @@ public extension JellyfinClient {
         ]))
     }
     
-    func playbackStopped(identifier: String, positionSeconds: Double) async throws {
-        let _ = try await request(ClientRequest<EmptyResponse>(path: "Sessions/Playing/Stopped", method: "POST", body: [
+    func playbackStopped(identifier: String, positionSeconds: Double, playSessionId: String?) async throws {
+        var requstBody = [
             "ItemId": identifier,
             "PositionTicks": Int64(positionSeconds * 10_000_000),
-        ]))
+        ] as [String : Any]
+        if let sessionId = playSessionId {
+            requstBody["PlaySessionId"] = sessionId
+        }
+        let _ = try await request(ClientRequest<EmptyResponse>(path: "Sessions/Playing/Stopped", method: "POST", body: requstBody))
     }
 }

--- a/AmpFinKit/Sources/AFNetwork/Websocket/WebSocket+Methods.swift
+++ b/AmpFinKit/Sources/AFNetwork/Websocket/WebSocket+Methods.swift
@@ -15,7 +15,7 @@ public extension JellyfinWebSocket {
         }
         
         var request = URLRequest(url: serverUrl.appending(path: "socket").appending(queryItems: [
-            URLQueryItem(name: "api_key", value: token),
+            URLQueryItem(name: "ApiKey", value: token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
         ]))
         request.timeoutInterval = 5

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -13,7 +13,7 @@ import AFNetwork
 extension DownloadManager {
     func download(trackId: String) -> URLSessionDownloadTask {
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: trackId).appending(path: "universal").appending(queryItems: [
-            URLQueryItem(name: "api_key", value: JellyfinClient.shared.token),
+            URLQueryItem(name: "ApiKey", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
             URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif"),

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -28,6 +28,9 @@ extension DownloadManager {
             url = url.appending(queryItems: [
                 URLQueryItem(name: "maxStreamingBitrate", value: "\(UInt64(bitrate) * 1000)")
             ])
+            url = url.appending(queryItems: [
+                URLQueryItem(name: "PlaySessionId", value: Session.getSessionId(profileString: "\(trackId)\(bitrate)")),
+            ])
         }
         
         return urlSession.downloadTask(with: URLRequest(url: url))

--- a/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Cleanup.swift
+++ b/AmpFinKit/Sources/AFOffline/OfflineManager/OfflineManager+Cleanup.swift
@@ -38,7 +38,7 @@ public extension OfflineManager {
         
         Task.detached {
             for play in plays {
-                try await JellyfinClient.shared.playbackStopped(identifier: play.trackIdentifier, positionSeconds: play.position)
+                try await JellyfinClient.shared.playbackStopped(identifier: play.trackIdentifier, positionSeconds: play.position, playSessionId: nil)
                 
                 await MainActor.run {
                     PersistenceManager.shared.modelContainer.mainContext.delete(play)

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
@@ -74,7 +74,7 @@ internal extension LocalAudioEndpoint {
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
             URLQueryItem(name: "PlaySessionId", value: LocalAudioEndpoint.getSessionId(profileString: "\(track.id)\(maxBitrate ?? 0)")),
-            URLQueryItem(name: "container", value: "ts|mp3,aac,m4a|aac,m4b|aac,mp4|flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif"),
+            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif"),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),
             URLQueryItem(name: "transcodingContainer", value: "mp4"),

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Rasmus Krämer on 19.03.24.
 //
@@ -8,6 +8,7 @@
 import Foundation
 import Network
 import AVKit
+import CryptoKit
 import Defaults
 
 import AFFoundation
@@ -23,56 +24,57 @@ internal extension LocalAudioEndpoint {
         get async {
             if let itemId = nowPlaying?.id {
                 let serverBitrateLikelyToBeFalse = DownloadManager.shared.downloaded(trackId: itemId) && Defaults[.maxDownloadBitrate] > 0
-                
+
                 if !serverBitrateLikelyToBeFalse, var mediaInfo = try? await JellyfinClient.shared.mediaInfo(trackId: itemId) {
                     guard let maxBitrate, let bitrate = mediaInfo.bitrate else {
                         return mediaInfo
                     }
-                    
+
                     let maxBitrateBits = maxBitrate * 1000
-                    
+
                     if (bitrate > maxBitrateBits) {
                         mediaInfo.bitrate = maxBitrateBits
                         mediaInfo.codec = "AAC"
                         mediaInfo.lossless = false
                     }
-                    
+
                     return mediaInfo
                 }
             }
-            
+
             let track = try? await audioPlayer.currentItem?.asset.load(.tracks).first
-            
+
             var format = await track?.mediaFormat()
             let bitrate = try? await track?.load(.estimatedDataRate)
-            
+
             if format != nil {
                 while format!.starts(with: ".") {
                     format!.removeFirst()
                 }
             }
-            
+
             var bitrateInt: Int?
             if let bitrate, bitrate > 0 {
                 bitrateInt = Int(bitrate)
             }
-            
+
             return .init(codec: format, lossless: false, bitrate: bitrateInt, bitDepth: nil, sampleRate: nil)
         }
     }
-    
+
     func avPlayerItem(track: Track) -> AVPlayerItem {
         #if canImport(AFOffline)
         if DownloadManager.shared.downloaded(trackId: track.id) {
             return AVPlayerItem(url: DownloadManager.shared.url(trackId: track.id))
         }
         #endif
-        
+
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: track.id).appending(path: "universal").appending(queryItems: [
-            URLQueryItem(name: "api_key", value: JellyfinClient.shared.token),
+            URLQueryItem(name: "ApiKey", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
-            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif"),
+            URLQueryItem(name: "PlaySessionId", value: LocalAudioEndpoint.getSessionId(profileString: "\(track.id)\(maxBitrate ?? 0)")),
+            URLQueryItem(name: "container", value: "ts|mp3,aac,m4a|aac,m4b|aac,mp4|flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif"),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),
             URLQueryItem(name: "transcodingContainer", value: "mp4"),
@@ -84,10 +86,10 @@ internal extension LocalAudioEndpoint {
                 URLQueryItem(name: "maxStreamingBitrate", value: "\(UInt64(bitrate) * 1000)")
             ])
         }
-        
+
         return AVPlayerItem(url: url)
     }
-    
+
     func setupNetworkPathMonitor() {
         networkMonitor.pathUpdateHandler = { [weak self] networkPath in
             guard let self = self else { return }
@@ -106,32 +108,33 @@ internal extension LocalAudioEndpoint {
     func determineBitrate() {
         let currentPath = networkMonitor.currentPath
         let bitrate: Int
-        
+
         if currentPath.isExpensive || currentPath.isConstrained {
             bitrate = Defaults[.maxConstrainedBitrate]
         } else {
             bitrate = Defaults[.maxStreamingBitrate]
         }
-        
+
         if bitrate <= 0 {
             maxBitrate = nil
         } else {
             maxBitrate = bitrate
         }
     }
-    
+
     func bitrateDidChange() async {
+        determineBitrate()
         let currentTime = currentTime
-        
+
         avPlayerQueue = []
         populateAVPlayerQueue()
-        
+
         await seek(seconds: currentTime)
         await MainActor.run {
             NotificationCenter.default.post(name: AudioPlayer.bitrateChangedNotification, object: nil)
         }
     }
-    
+
     func updatePlaybackReporter(scheduled: Bool) {
         playbackReporter?.update(
             positionSeconds: currentTime,
@@ -141,20 +144,28 @@ internal extension LocalAudioEndpoint {
             volume: volume,
             scheduled: scheduled)
     }
-    
+
     func setNowPlaying(track: Track?) {
         nowPlaying = track
-        
+
         if let track = track {
             AudioPlayer.current.updateCommandCenter(favorite: track.favorite)
-            playbackReporter = PlaybackReporter(trackId: track.id, queue: queue)
+            playbackReporter = PlaybackReporter(trackId: track.id, playSessionId: LocalAudioEndpoint.getSessionId(profileString: "\(track.id)\(maxBitrate ?? 0)"), queue: queue)
         } else {
             playbackReporter = nil
         }
     }
-    
+
     static func audioRoute() -> AudioPlayer.AudioRoute {
         let output = AVAudioSession.sharedInstance().currentRoute.outputs.first
         return .init(port: output?.portType ?? .builtInSpeaker, name: output?.portName ?? "-/-")
+    }
+
+    static func getSessionId(profileString: String) -> String {
+        let digest = Insecure.MD5.hash(data: Data(profileString.utf8))
+
+        return digest.map {
+            String(format: "%02hhx", $0)
+        }.joined()
     }
 }

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/PlaybackReporter.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/PlaybackReporter.swift
@@ -17,7 +17,7 @@ import AFOffline
 
 public final class PlaybackReporter {
     let trackId: String
-    let playSessionId: String
+    var playSessionId: String
     
     var currentTime: Double = 0
     

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/PlaybackReporter.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/PlaybackReporter.swift
@@ -17,18 +17,20 @@ import AFOffline
 
 public final class PlaybackReporter {
     let trackId: String
+    let playSessionId: String
     
     var currentTime: Double = 0
     
-    init(trackId: String, queue: [Track]) {
+    init(trackId: String, playSessionId: String, queue: [Track]) {
         self.trackId = trackId
+        self.playSessionId = playSessionId
         
         Task {
             try? await JellyfinClient.shared.playbackStarted(identifier: trackId, queueIds: queue.map { $0.id })
         }
     }
     deinit {
-        PlaybackReporter.playbackStopped(trackId: trackId, currentTime: currentTime)
+        PlaybackReporter.playbackStopped(trackId: trackId, currentTime: currentTime, playSessionId: playSessionId)
     }
     
     func update(positionSeconds: Double, paused: Bool, repeatMode: RepeatMode, shuffled: Bool, volume: Float, scheduled: Bool) {
@@ -61,10 +63,10 @@ public final class PlaybackReporter {
 }
 
 extension PlaybackReporter {
-    static func playbackStopped(trackId: String, currentTime: Double) {
+    static func playbackStopped(trackId: String, currentTime: Double, playSessionId: String?) {
         Task {
             do {
-                try await JellyfinClient.shared.playbackStopped(identifier: trackId, positionSeconds: currentTime)
+                try await JellyfinClient.shared.playbackStopped(identifier: trackId, positionSeconds: currentTime, playSessionId: playSessionId)
             } catch {
                 #if canImport(AFOffline)
                 await OfflineManager.shared.cache(position: currentTime, trackId: trackId)


### PR DESCRIPTION
After further investigation, I noticed that the server's cache behavior is actually controllable. The client can supply a `PlaySessionId` in the request query string, which will be passed to the HLS builder and ultimately the transcode manager. When the client does not specify a session ID, the transcoder will only hash the transcode output filename with the input filename, the user agent, and the device ID. These values do not change if the client device is the same and is requesting the same audio file, effectively caching the transcoded file for that client for 24 hours.

When the client supplies a session ID, the server will hash the transcoded filename additionally with the session ID, so that requests from the same device will not share the cache when the session ID is different. This PR added a mechanism to use the session ID to control the server cache behavior. When requesting the audio stream, hash the `trackId` and the current bitrate limit as the `PlaySessionId`. This would force the server to generate a new stream immediately when the bitrate limit has changed. The preloading would still work when the bitrate limit does not change, as the `PlaySessionId` would still be the same in this case, meaning the server would return the pre-generated HLS playlist instead of creating a new one.

When playback is confirmed to stop, we can supply this `PlaySessionId` to the `ReportPlaybackStopped` endpoint. The server would then look up if this `PlaySessionId` has an associated transcoding job, and if so, it will clean the transcoded files. For any reason that the playback stopped event is not sent to the server, the file will be cleaned in 24 hours.

This PR also changed the deprecated `api_key` query string to new `ApiKey`. We are going to remove some deprecated endpoints in 10.10 so change the query string to accommodate for this change. This query string would still work for 10.9 servers. I have not tested this with 10.8 server though, and if that does not work you might want to add extra options.

The download logic has not changed yet because I'm still thinking about the correct way of doing that. Obviously downloads does not call the playback has stopped endpoint so the files are not cleaned up. Is it OK to leave the transcode cache stay for 24hours?