### PR TITLE
Refactor LoginView for improved UX

### DIFF
--- a/Multiplatform/Account/CustomHeaderEditView.swift
+++ b/Multiplatform/Account/CustomHeaderEditView.swift
@@ -45,6 +45,12 @@ struct CustomHeaderEditView: View {
                 }
                 
                 Button {
+                    
+                    // Remove empty headers, as that causes requests to fail
+                    current = current.filter { element in
+                        !element.key.isEmpty && !element.value.isEmpty
+                    }
+                    
                     JellyfinClient.shared.customHTTPHeaders = current
                     callback?()
                 } label: {

--- a/Multiplatform/Account/LoginView.swift
+++ b/Multiplatform/Account/LoginView.swift
@@ -109,9 +109,11 @@ struct LoginView: View {
                     }
                     .onSubmit(flowStep)
                 case .customHTTPHeaders:
+                NavigationView {
                     CustomHeaderEditView() {
                         loginFlowState = .server
                     }
+                }
                 case .serverLoading, .credentialsLoading:
                     VStack {
                         ProgressView()

--- a/Multiplatform/Account/LoginView.swift
+++ b/Multiplatform/Account/LoginView.swift
@@ -53,7 +53,8 @@ struct LoginView: View {
             Spacer()
         }
         .sheet(isPresented: $loginSheetPresented, content: {
-            switch loginFlowState {
+            NavigationView {
+                switch loginFlowState {
                 case .server, .credentials:
                     Form {
                         Section {
@@ -83,14 +84,14 @@ struct LoginView: View {
                         } footer: {
                             Group {
                                 switch loginError {
-                                    case .server:
-                                        Text("login.error.server")
-                                    case .url:
-                                        Text("login.error.url")
-                                    case .failed:
-                                        Text("login.error.failed")
-                                    case nil:
-                                        EmptyView()
+                                case .server:
+                                    Text("login.error.server")
+                                case .url:
+                                    Text("login.error.url")
+                                case .failed:
+                                    Text("login.error.failed")
+                                case nil:
+                                    EmptyView()
                                 }
                             }
                             .foregroundStyle(.red)
@@ -107,13 +108,22 @@ struct LoginView: View {
                             }
                         }
                     }
+                    .toolbar {
+                        if loginFlowState == .credentials {
+                            ToolbarItemGroup(placement: .topBarLeading) {
+                                Button {
+                                    loginFlowState = .server
+                                } label: {
+                                    Label("back", systemImage: "chevron.left")
+                                }
+                            }
+                        }   
+                    }
                     .onSubmit(flowStep)
                 case .customHTTPHeaders:
-                NavigationView {
                     CustomHeaderEditView() {
                         loginFlowState = .server
                     }
-                }
                 case .serverLoading, .credentialsLoading:
                     VStack {
                         ProgressView()
@@ -123,6 +133,7 @@ struct LoginView: View {
                             .foregroundStyle(.secondary)
                             .padding(20)
                     }
+                }
             }
         })
     }


### PR DESCRIPTION
This fixes the Custom HTTP-Headers edit view being un-exitable when accesed via the login page.

|     Current/Previous Behavior    | New Behavior |
|:------------:|:----:|
| ![image](https://github.com/user-attachments/assets/c796ab5c-bd69-4467-a685-0d2f30077f9f) | ![image](https://github.com/user-attachments/assets/5b388313-c3c4-43f7-bd3f-dd446ae64aa6) |