### PR TITLE
feat: Support setting default privacy setting for new playlists

### DIFF
--- a/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
+++ b/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
@@ -26,7 +26,9 @@ struct PlaylistAddSheet: View {
     
     init(track: Track){
         self.track = track
-        self.publicPlaylist = !Defaults[.newPlaylistDefaultPrivate]
+        if JellyfinClient.shared.supports(.sharedPlaylists) {
+            self._publicPlaylist = State(initialValue: !Defaults[.newPlaylistDefaultPrivate])
+        }
     }
     var body: some View {
         NavigationStack {

--- a/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
+++ b/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AmpFinKit
+import Defaults
 
 struct PlaylistAddSheet: View {
     @Environment(\.colorScheme) private var colorScheme
@@ -23,6 +24,10 @@ struct PlaylistAddSheet: View {
     
     @State private var playlists: [Playlist]?
     
+    init(track: Track){
+        self.track = track
+        self.publicPlaylist = !Defaults[.newPlaylistDefaultPrivate]
+    }
     var body: some View {
         NavigationStack {
             Group {

--- a/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
+++ b/Multiplatform/Collections/Playlists/PlaylistAddSheet.swift
@@ -17,19 +17,14 @@ struct PlaylistAddSheet: View {
     
     @State private var creatingNewPlaylist = false
     @State private var newPlaylistName = ""
-    @State private var publicPlaylist: Bool = true
+    // Older Jellyfin servers that don't support private playlists are set to true to avoid user confusion, otherwise it checks the user's preference
+    @State private var publicPlaylist: Bool = JellyfinClient.shared.supports(.sharedPlaylists) ? !Defaults[.newPlaylistDefaultPrivate] : true 
     
     @State private var failed = false
     @State private var working = false
     
     @State private var playlists: [Playlist]?
     
-    init(track: Track){
-        self.track = track
-        if JellyfinClient.shared.supports(.sharedPlaylists) {
-            self._publicPlaylist = State(initialValue: !Defaults[.newPlaylistDefaultPrivate])
-        }
-    }
     var body: some View {
         NavigationStack {
             Group {

--- a/Multiplatform/Settings.bundle/Root.plist
+++ b/Multiplatform/Settings.bundle/Root.plist
@@ -38,6 +38,16 @@
 		</dict>
 		<dict>
 			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Default new playlists as private</string>
+			<key>Key</key>
+			<string>newPlaylistDefaultPrivate</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>Audio-Quality</string>

--- a/Multiplatform/Utility/Extensions/Defaults+Keys.swift
+++ b/Multiplatform/Utility/Extensions/Defaults+Keys.swift
@@ -41,4 +41,5 @@ internal extension Defaults.Keys {
     static let artistInstantMix = Key("artistInstantMix", default: false)
     static let libraryRandomAlbums = Key("libraryRandomAlbums", default: false)
     static let haltNowPlayingBackground = Key("haltNowPlayingBackground", default: false)
+    static let newPlaylistDefaultPrivate = Key<Bool>("newPlaylistDefaultPrivate", default: false)
 }


### PR DESCRIPTION
Via the AmpFin settings, users can toggle the "Default new playlists as private" option. When that toggle is active, the "Shared with Instance" option in the PlaylistAddSheet view will, by default, set to off. Alternatively, when the toggle is set to inactive, the "Shared with Instance" option in the PlaylistAddSheet view will, by default, set to on.

| AmpFin Settings Page    | Example of disabled by default toggle |
| -------- | ------- |
|  ![image](https://github.com/user-attachments/assets/0f38f590-d997-45fb-949b-7bfc85f400ee) | ![image](https://github.com/user-attachments/assets/588f2ec1-bc38-4e95-8d64-8023f66368f7)   |
