### PR TITLE
[feat] Login with Quick Connect

### DIFF
--- a/AmpFin.xcodeproj/project.pbxproj
+++ b/AmpFin.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		3AF3BA982C525E2900C96E1F /* QueueButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF3BA972C525E2900C96E1F /* QueueButtons.swift */; };
 		3AF815DD2AAA1A80004BA444 /* Lyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF815DC2AAA1A80004BA444 /* Lyrics.swift */; };
 		3AFCD1212BC5CB6A00589301 /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFCD1202BC5CB6A00589301 /* Buttons.swift */; };
+		EAB1E6C52CA69AFC0094D8EF /* LoginQuickConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB1E6C42CA69AF20094D8EF /* LoginQuickConnectView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -271,6 +272,7 @@
 		3AF3BA972C525E2900C96E1F /* QueueButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueButtons.swift; sourceTree = "<group>"; };
 		3AF815DC2AAA1A80004BA444 /* Lyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lyrics.swift; sourceTree = "<group>"; };
 		3AFCD1202BC5CB6A00589301 /* Buttons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
+		EAB1E6C42CA69AF20094D8EF /* LoginQuickConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginQuickConnectView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -643,6 +645,7 @@
 				3AEB32292AA7EC3C00853210 /* LoginView.swift */,
 				3A3AF1A52AC4523600811D7D /* AccountSheet.swift */,
 				3ABF77E42C87452C0006ADBC /* CustomHeaderEditView.swift */,
+				EAB1E6C42CA69AF20094D8EF /* LoginQuickConnectView.swift */,
 				3A36ED3E2BE8EDD200AECE9C /* Account+Remote.swift */,
 			);
 			path = Account;
@@ -884,6 +887,7 @@
 				3AA0AFAA2BE540500084B7A1 /* NowPlaying.swift in Sources */,
 				3AAE1B442BC57AFB00FD0200 /* Sidebar+Selection.swift in Sources */,
 				3AC65BDB2BE224D500448D5E /* Array+Repeat.swift in Sources */,
+				EAB1E6C52CA69AFC0094D8EF /* LoginQuickConnectView.swift in Sources */,
 				3A5515F42BC4391300B922D7 /* Sidebar+Links.swift in Sources */,
 				3A773C5B2BA5F2F2005FD583 /* ContextMenuModifier.swift in Sources */,
 				3A3DA66D2AAB2EAE0091211A /* ArtistView+Header.swift in Sources */,

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
@@ -49,12 +49,16 @@ public extension JellyfinClient {
             case .sharedPlaylists, .lyrics:
                 // Required 10.9+
                 return serverVersion.major >= 10 && serverVersion.minor >= 9
+            case .quickConnect:
+                // Required 10.7+
+                return serverVersion.major >= 10 && serverVersion.minor >= 7
         }
     }
     
     enum FeatureFlag: Identifiable, Hashable, Codable {
         case lyrics
         case sharedPlaylists
+        case quickConnect
         
         public var id: Self {
             self

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
@@ -52,6 +52,11 @@ public extension JellyfinClient {
             case .quickConnect:
                 // Required 10.7+
                 return serverVersion.major >= 10 && serverVersion.minor >= 7
+            case .legacyQuickConnect:
+                // Quick Connect before 10.9.0 used GET instead of POST
+                // GET is required from 10.7.0 until 10.8.13
+            return
+                serverVersion.major == 10 && serverVersion.minor >= 7 && serverVersion.minor <= 8
         }
     }
     
@@ -59,6 +64,7 @@ public extension JellyfinClient {
         case lyrics
         case sharedPlaylists
         case quickConnect
+        case legacyQuickConnect
         
         public var id: Self {
             self

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
@@ -54,9 +54,11 @@ public extension JellyfinClient {
                 return serverVersion.major >= 10 && serverVersion.minor >= 7
             case .legacyQuickConnect:
                 // Quick Connect before 10.9.0 used GET instead of POST
-                // GET is required from 10.7.0 until 10.8.13
-            return
-                serverVersion.major == 10 && serverVersion.minor >= 7 && serverVersion.minor <= 8
+                // GET is required from 10.7.0 until 10.8.x
+                return serverVersion.major == 10 && (serverVersion.minor == 7 || serverVersion.minor == 8)
+            case .legacyQuickConnectStatus:
+                // Version 10.7.x uses GET /QuickConnect/Status
+                return serverVersion.major == 10 && serverVersion.minor == 7
         }
     }
     
@@ -65,6 +67,7 @@ public extension JellyfinClient {
         case sharedPlaylists
         case quickConnect
         case legacyQuickConnect
+        case legacyQuickConnectStatus
         
         public var id: Self {
             self

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
@@ -50,15 +50,8 @@ public extension JellyfinClient {
                 // Required 10.9+
                 return serverVersion.major >= 10 && serverVersion.minor >= 9
             case .quickConnect:
-                // Required 10.7+
-                return serverVersion.major >= 10 && serverVersion.minor >= 7
-            case .legacyQuickConnect:
-                // Quick Connect before 10.9.0 used GET instead of POST
-                // GET is required from 10.7.0 until 10.8.x
-                return serverVersion.major == 10 && (serverVersion.minor == 7 || serverVersion.minor == 8)
-            case .legacyQuickConnectStatus:
-                // Version 10.7.x uses GET /QuickConnect/Status
-                return serverVersion.major == 10 && serverVersion.minor == 7
+                // Required 10.7+, but AmpFin will only support 10.9+
+                return serverVersion.major >= 10 && serverVersion.minor >= 9
         }
     }
     
@@ -66,8 +59,6 @@ public extension JellyfinClient {
         case lyrics
         case sharedPlaylists
         case quickConnect
-        case legacyQuickConnect
-        case legacyQuickConnectStatus
         
         public var id: Self {
             self

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
@@ -1,0 +1,36 @@
+//
+//  JellyfinClient+QuickConnect.swift
+//  AmpFin
+// 
+// Created by Daniel Cuevas on 9/28/24 at 1:39 AM.
+// 
+    
+
+import Foundation
+
+public extension JellyfinClient {
+    func checkIfQuickConnectIsAvailable() async throws -> Bool {
+        let response = try await request(ClientRequest<Bool>(path: "/QuickConnect/Enabled", method: "GET"))
+        
+        return response
+    }
+    
+    func initiateQuickConnect() async throws -> (String, String, String, String) {
+        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/initiate", method: "POST"))
+        
+        return (
+            response.Code,
+            response.DeviceId,
+            response.DeviceName,
+            response.Secret
+        )
+    }
+    
+    func verifyQuickConnect(secret: String) async throws -> Bool {
+        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/Connect", method: "GET", query:[
+            URLQueryItem(name: "Secret", value: secret)
+        ]))
+        
+        return response.Authenticated
+    }
+}

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
@@ -10,26 +10,16 @@ import Foundation
 
 public extension JellyfinClient {
     func checkIfQuickConnectIsAvailable() async throws -> Bool {
-        if JellyfinClient.shared.supports(.legacyQuickConnectStatus)  {
-            let response = try await request(ClientRequest<String>(path: "/QuickConnect/Status", method: "GET"))
-            
-            return response == "Active"
-        } else if JellyfinClient.shared.supports(.quickConnect) {
-            let response = try await request(ClientRequest<Bool>(path: "/QuickConnect/Enabled", method: "GET"))
-            
-            return response
-        } else {
+        if !JellyfinClient.shared.supports(.quickConnect) {
             return false
         }
+        let response = try await request(ClientRequest<Bool>(path: "/QuickConnect/Enabled", method: "GET"))
+        
+        return response
     }
     
     func initiateQuickConnect() async throws -> (String, String) {
-        var method = "POST"
-        if JellyfinClient.shared.supports(.legacyQuickConnect) {
-            method = "GET"
-        }
-        
-        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/initiate", method: method))
+        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/initiate", method: "POST"))
         
         return (
             response.Code,
@@ -37,11 +27,11 @@ public extension JellyfinClient {
         )
     }
     
-    func verifyQuickConnect(secret: String) async throws -> (Bool, String?) {
+    func verifyQuickConnect(secret: String) async throws -> Bool {
         let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/Connect", method: "GET", query:[
             URLQueryItem(name: "Secret", value: secret)
         ]))
         
-        return (response.Authenticated, response.Authentication)
+        return response.Authenticated
     }
 }

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
@@ -10,12 +10,20 @@ import Foundation
 
 public extension JellyfinClient {
     func checkIfQuickConnectIsAvailable() async throws -> Bool {
-        let response = try await request(ClientRequest<Bool>(path: "/QuickConnect/Enabled", method: "GET"))
-        
-        return response
+        if JellyfinClient.shared.supports(.legacyQuickConnectStatus)  {
+            let response = try await request(ClientRequest<String>(path: "/QuickConnect/Status", method: "GET"))
+            
+            return response == "Active"
+        } else if JellyfinClient.shared.supports(.quickConnect) {
+            let response = try await request(ClientRequest<Bool>(path: "/QuickConnect/Enabled", method: "GET"))
+            
+            return response
+        } else {
+            return false
+        }
     }
     
-    func initiateQuickConnect() async throws -> (String, String, String, String) {
+    func initiateQuickConnect() async throws -> (String, String) {
         var method = "POST"
         if JellyfinClient.shared.supports(.legacyQuickConnect) {
             method = "GET"
@@ -25,17 +33,15 @@ public extension JellyfinClient {
         
         return (
             response.Code,
-            response.DeviceId,
-            response.DeviceName,
             response.Secret
         )
     }
     
-    func verifyQuickConnect(secret: String) async throws -> Bool {
+    func verifyQuickConnect(secret: String) async throws -> (Bool, String?) {
         let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/Connect", method: "GET", query:[
             URLQueryItem(name: "Secret", value: secret)
         ]))
         
-        return response.Authenticated
+        return (response.Authenticated, response.Authentication)
     }
 }

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+QuickConnect.swift
@@ -16,7 +16,12 @@ public extension JellyfinClient {
     }
     
     func initiateQuickConnect() async throws -> (String, String, String, String) {
-        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/initiate", method: "POST"))
+        var method = "POST"
+        if JellyfinClient.shared.supports(.legacyQuickConnect) {
+            method = "GET"
+        }
+        
+        let response = try await request(ClientRequest<QuickConnectResponse>(path: "/QuickConnect/initiate", method: method))
         
         return (
             response.Code,

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
@@ -23,10 +23,8 @@ public extension JellyfinClient {
     }
     
     func loginWithQuickConnect(secret: String) async throws -> (String, String) {
-        // 10.7.x uses "Token" as the key name instead of "Secret" used in later versions
-        let keyName = JellyfinClient.shared.supports(.legacyQuickConnectStatus) ? "Token" : "Secret"
         let response = try await request(ClientRequest<AuthenticateByNameOrQuickConnectResponse>(path: "Users/AuthenticateWithQuickConnect", method: "POST", body: [
-            keyName: secret
+            "Secret": secret
         ]))
         
         return (response.AccessToken, response.User.Id)

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
@@ -23,8 +23,10 @@ public extension JellyfinClient {
     }
     
     func loginWithQuickConnect(secret: String) async throws -> (String, String) {
+        // 10.7.x uses "Token" as the key name instead of "Secret" used in later versions
+        let keyName = JellyfinClient.shared.supports(.legacyQuickConnectStatus) ? "Token" : "Secret"
         let response = try await request(ClientRequest<AuthenticateByNameOrQuickConnectResponse>(path: "Users/AuthenticateWithQuickConnect", method: "POST", body: [
-            "Secret": secret
+            keyName: secret
         ]))
         
         return (response.AccessToken, response.User.Id)

--- a/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
+++ b/AmpFinKit/Sources/AFNetwork/Methods/JellyfinClient+User.swift
@@ -14,9 +14,17 @@ public extension JellyfinClient {
     }
     
     func login(username: String, password: String) async throws -> (String, String) {
-        let response = try await request(ClientRequest<AuthenticateByNameResponse>(path: "Users/authenticatebyname", method: "POST", body: [
+        let response = try await request(ClientRequest<AuthenticateByNameOrQuickConnectResponse>(path: "Users/authenticatebyname", method: "POST", body: [
             "Username": username,
             "Pw": password,
+        ]))
+        
+        return (response.AccessToken, response.User.Id)
+    }
+    
+    func loginWithQuickConnect(secret: String) async throws -> (String, String) {
+        let response = try await request(ClientRequest<AuthenticateByNameOrQuickConnectResponse>(path: "Users/AuthenticateWithQuickConnect", method: "POST", body: [
+            "Secret": secret
         ]))
         
         return (response.AccessToken, response.User.Id)

--- a/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
+++ b/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
@@ -57,7 +57,7 @@ internal struct PublicServerInfoResponse: Codable {
     let StartupWizardCompleted: Bool
 }
 
-internal struct AuthenticateByNameResponse: Codable {
+internal struct AuthenticateByNameOrQuickConnectResponse: Codable {
     let AccessToken: String
     let User: User
     
@@ -80,4 +80,15 @@ internal struct LyricsResponse: Codable {
         let Start: Int64
         let Text: String
     }
+}
+
+internal struct QuickConnectResponse: Codable {
+    let AppName: String
+    let AppVersion: String
+    let Authenticated: Bool
+    let Code: String
+    let DateAdded: String
+    let DeviceId: String
+    let DeviceName: String
+    let Secret: String
 }

--- a/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
+++ b/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
@@ -57,6 +57,17 @@ internal struct PublicServerInfoResponse: Codable {
     let StartupWizardCompleted: Bool
 }
 
+internal struct PublicServerInfoV10_6Response: Codable {
+    let LocalAddress: String
+    let ServerName: String
+    let Version: String
+    let ProductName: String
+    let OperatingSystem: String
+    let Id: String
+}
+
+
+
 internal struct AuthenticateByNameOrQuickConnectResponse: Codable {
     let AccessToken: String
     let User: User
@@ -83,12 +94,13 @@ internal struct LyricsResponse: Codable {
 }
 
 internal struct QuickConnectResponse: Codable {
-    let AppName: String
-    let AppVersion: String
+    let AppName: String? // May be nil for legacy Quick Connect
+    let AppVersion: String? // May be nil for legacy Quick Connect
     let Authenticated: Bool
+    let Authentication: String? // Quick Connect 10.7
     let Code: String
     let DateAdded: String
-    let DeviceId: String
-    let DeviceName: String
+    let DeviceId: String? // May be nil for legacy Quick Connect
+    let DeviceName: String? // May be nil for legacy Quick Connect
     let Secret: String
 }

--- a/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
+++ b/AmpFinKit/Sources/AFNetwork/Models/JellyfinUtility.swift
@@ -94,13 +94,12 @@ internal struct LyricsResponse: Codable {
 }
 
 internal struct QuickConnectResponse: Codable {
-    let AppName: String? // May be nil for legacy Quick Connect
-    let AppVersion: String? // May be nil for legacy Quick Connect
+    let AppName: String
+    let AppVersion: String
     let Authenticated: Bool
-    let Authentication: String? // Quick Connect 10.7
     let Code: String
     let DateAdded: String
-    let DeviceId: String? // May be nil for legacy Quick Connect
-    let DeviceName: String? // May be nil for legacy Quick Connect
+    let DeviceId: String
+    let DeviceName: String
     let Secret: String
 }

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -10,10 +10,11 @@ import AmpFinKit
 
 internal struct LoginQuickConnectView: View {
     let dismiss: (() -> Void)
-    @State var code: String?
-    @State var secret: String = ""
-    @State var success: Bool = false
-    @State var caughtError: Bool = false
+    @State private var code: String?
+    @State private var secret: String = ""
+    @State private var success: Bool = false
+    @State private var caughtError: Bool = false
+    @State private var expired: Bool = false
     
     var body: some View {
         

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -57,13 +57,15 @@ internal struct LoginQuickConnectView: View {
         .onAppear() {
                 Task {
                     do {
-                        try await JellyfinClient.shared.updateCachedServerVersion()
-                        let (Code, _, _, Secret) = try await JellyfinClient.shared.initiateQuickConnect()
+                        let (Code, Secret) = try await JellyfinClient.shared.initiateQuickConnect()
                         self.code = Code
                         self.secret = Secret
                         repeat {
-                            let authorized = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
+                            let (authorized, authorizationToken) = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
                             if authorized {
+                                if authorizationToken != nil {
+                                    self.secret = authorizationToken
+                                }
                                 self.success = true
                                 Task {
                                     do {

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -51,13 +51,6 @@ internal struct LoginQuickConnectView: View {
                     .padding(.top, 4)
                     .padding(.bottom, 20)
                     .foregroundStyle(.secondary)
-                
-                
-                Button("login.quickconnect.copy", systemImage: "doc.on.doc") {
-                    UIPasteboard.general.string = code
-                }
-                .foregroundColor(.accentColor)
-                .disabled(code == nil)
             }
             .padding(.vertical, 40)
         }

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -11,7 +11,7 @@ import AmpFinKit
 internal struct LoginQuickConnectView: View {
     let dismiss: (() -> Void)
     @State var code: String?
-    @State var secret: String?
+    @State var secret: String = ""
     @State var success: Bool = false
     @State var caughtError: Bool = false
     
@@ -61,15 +61,12 @@ internal struct LoginQuickConnectView: View {
                         self.code = Code
                         self.secret = Secret
                         repeat {
-                            let (authorized, authorizationToken) = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
+                            let authorized = try await JellyfinClient.shared.verifyQuickConnect(secret: self.secret)
                             if authorized {
-                                if authorizationToken != nil {
-                                    self.secret = authorizationToken
-                                }
                                 self.success = true
                                 Task {
                                     do {
-                                        let (token, userId) =  try await JellyfinClient.shared.loginWithQuickConnect(secret: self.secret ?? "")
+                                        let (token, userId) =  try await JellyfinClient.shared.loginWithQuickConnect(secret: self.secret)
                                         
                                         JellyfinClient.shared.store(token: token)
                                         JellyfinClient.shared.store(userId: userId)

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -1,0 +1,105 @@
+//
+//  LoginQuickConnectView.swift
+//  AmpFin
+//
+//  Created by Daniel Cuevas on 9/27/24.
+//
+
+import SwiftUI
+import AmpFinKit
+
+internal struct LoginQuickConnectView: View {
+    let dismiss: (() -> Void)
+    @State var code: String?
+    @State var secret: String?
+    @State var success: Bool = false
+    @State var caughtError: Bool = false
+    
+    var body: some View {
+        if caughtError {
+            VStack {
+                Text("login.quickconnect.error")
+                Spacer()
+            }
+        }
+        
+        List {
+            Text("login.quickconnect.description")
+            
+            VStack(alignment: .center) {
+                HStack {
+                    Spacer()
+                    Text("login.quickconnect.code.title")
+                    Spacer()
+                }
+                
+                HStack {
+                    Spacer()
+                    Text(code ?? "??????")
+                        .font(.title)
+                    Spacer()
+                }
+            }
+            
+            HStack {
+                ProgressView()
+                Text(success ? "login.quickconnect.success" :(code != nil ? "login.quickconnect.waiting" : "login.quickconnect.preparing"))
+            }
+           
+            
+            Button("login.quickconnect.copy", systemImage: "doc.on.doc") {
+                UIPasteboard.general.string = code
+            }
+            .foregroundColor(.accentColor)
+            .disabled(code == nil)
+        }
+        .interactiveDismissDisabled(success)
+        .onAppear() {
+            do {
+                Task {
+                    
+                    let (Code, _, _, Secret) = try await JellyfinClient.shared.initiateQuickConnect()
+                    self.code = Code
+                    self.secret = Secret
+                    repeat {
+                        let authorized = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
+                        if authorized {
+                            self.success = true
+                            Task {
+                                do {
+                                    let (token, userId) =  try await JellyfinClient.shared.loginWithQuickConnect(secret: self.secret ?? "")
+                                    
+                                    JellyfinClient.shared.store(token: token)
+                                    JellyfinClient.shared.store(userId: userId)
+                                } catch {
+                                    caughtError = true
+                                }
+                            }
+                            throw CancellationError()
+                        }
+
+                        try? await Task.sleep(for: .seconds(5))
+                    } while (!Task.isCancelled)
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Label("done", systemImage: "chevron.left")
+                        .labelStyle(.iconOnly)
+                } .disabled(success)
+            }
+        }
+        .navigationTitle("login.quickconnect.title")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LoginQuickConnectView() {}
+    }
+}

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -23,17 +23,25 @@ internal struct LoginQuickConnectView: View {
                 Spacer()
                 
                 if caughtError {
-                    VStack {
-                        Text("login.quickconnect.error")
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                        Spacer()
-                    }
+                    Text("login.quickconnect.error")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Spacer()
                 }
                 
-                Text(code ?? "??????")
-                    .font(.largeTitle)
+                Text("login.quickconnect.hint")
+                    .font(.caption)
                     .padding(.bottom, 20)
+                
+                Button {
+                    UIPasteboard.general.string = code
+                } label: {
+                    Text(code ?? "??????")
+                        .font(.largeTitle)
+                        .monospaced()
+                        .padding(.bottom, 20)
+                }
+                
                 
                 
                 ProgressView()

--- a/Multiplatform/Account/LoginQuickConnectView.swift
+++ b/Multiplatform/Account/LoginQuickConnectView.swift
@@ -55,32 +55,32 @@ internal struct LoginQuickConnectView: View {
         }
         .interactiveDismissDisabled(success)
         .onAppear() {
-            do {
                 Task {
-                    
-                    let (Code, _, _, Secret) = try await JellyfinClient.shared.initiateQuickConnect()
-                    self.code = Code
-                    self.secret = Secret
-                    repeat {
-                        let authorized = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
-                        if authorized {
-                            self.success = true
-                            Task {
-                                do {
-                                    let (token, userId) =  try await JellyfinClient.shared.loginWithQuickConnect(secret: self.secret ?? "")
-                                    
-                                    JellyfinClient.shared.store(token: token)
-                                    JellyfinClient.shared.store(userId: userId)
-                                } catch {
-                                    caughtError = true
+                    do {
+                        try await JellyfinClient.shared.updateCachedServerVersion()
+                        let (Code, _, _, Secret) = try await JellyfinClient.shared.initiateQuickConnect()
+                        self.code = Code
+                        self.secret = Secret
+                        repeat {
+                            let authorized = try await JellyfinClient.shared.verifyQuickConnect(secret: secret ?? "")
+                            if authorized {
+                                self.success = true
+                                Task {
+                                    do {
+                                        let (token, userId) =  try await JellyfinClient.shared.loginWithQuickConnect(secret: self.secret ?? "")
+                                        
+                                        JellyfinClient.shared.store(token: token)
+                                        JellyfinClient.shared.store(userId: userId)
+                                    } catch {
+                                        caughtError = true
+                                    }
                                 }
+                                throw CancellationError()
                             }
-                            throw CancellationError()
-                        }
-
-                        try? await Task.sleep(for: .seconds(5))
-                    } while (!Task.isCancelled)
-                }
+               
+                            try? await Task.sleep(for: .seconds(5))
+                        } while (!Task.isCancelled)
+                    } 
             }
         }
         .toolbar {

--- a/Multiplatform/Account/LoginView.swift
+++ b/Multiplatform/Account/LoginView.swift
@@ -116,10 +116,8 @@ struct LoginView: View {
 
                                     }
                                     .disabled(!quickConnectAvailable)
-                                    
-                                    if !quickConnectAvailable {
-                                        Text("login.quickconnect.unavailable.description")
-                                    }
+                                } footer: {
+                                    Text("login.quickconnect.description")
                                 }
                             }
                             

--- a/Multiplatform/Account/LoginView.swift
+++ b/Multiplatform/Account/LoginView.swift
@@ -15,6 +15,7 @@ struct LoginView: View {
     @State private var server = JellyfinClient.shared.serverUrl?.absoluteString ?? "https://"
     @State private var username = ""
     @State private var password = ""
+    @State private var quickConnectAvailable: Bool = false
     
     @State private var serverVersion: String?
     @State private var loginError: LoginError?
@@ -95,6 +96,31 @@ struct LoginView: View {
                                     }
                                 }
                                 .foregroundStyle(.red)
+                                
+                                
+                            }
+                            
+                            if loginFlowState == .credentials {
+                                Section {
+                                    Button {
+                                        loginFlowState = .quickConnect
+                                    } label: {
+                                        if !quickConnectAvailable {
+                                            Label("login.quickconnect.unavailable.title", systemImage: "numbers.rectangle")
+                                                .foregroundStyle(.secondary)
+                                        } else {
+                                            Label("login.quickconnect.title", systemImage: "numbers.rectangle")
+                                                .foregroundStyle(.primary)
+                                        }
+                                    
+
+                                    }
+                                    .disabled(!quickConnectAvailable)
+                                    
+                                    if !quickConnectAvailable {
+                                        Text("login.quickconnect.unavailable.description")
+                                    }
+                                }
                             }
                             
                             if loginFlowState == .server {
@@ -115,6 +141,14 @@ struct LoginView: View {
                                 loginFlowState = .server
                             }
                         }
+                        
+                    case .quickConnect:
+                    NavigationStack {
+                        LoginQuickConnectView() {
+                            loginFlowState = .credentials
+                        }
+                    }
+                        
                     case .serverLoading, .credentialsLoading:
                         VStack {
                             ProgressView()
@@ -153,6 +187,7 @@ internal extension LoginView {
             Task {
                 do {
                     serverVersion = try await JellyfinClient.shared.serverVersion()
+                    quickConnectAvailable = try await JellyfinClient.shared.checkIfQuickConnectIsAvailable()
                 } catch {
                     loginError = .server
                     loginFlowState = .server
@@ -184,6 +219,7 @@ internal extension LoginView {
         case server
         case serverLoading
         case credentials
+        case quickConnect // used instead of credentials
         case credentialsLoading
         
         case customHTTPHeaders

--- a/Multiplatform/Account/LoginView.swift
+++ b/Multiplatform/Account/LoginView.swift
@@ -187,6 +187,7 @@ internal extension LoginView {
             Task {
                 do {
                     serverVersion = try await JellyfinClient.shared.serverVersion()
+                    try await JellyfinClient.shared.updateCachedServerVersion()
                     quickConnectAvailable = try await JellyfinClient.shared.checkIfQuickConnectIsAvailable()
                 } catch {
                     loginError = .server

--- a/Multiplatform/Localizable.xcstrings
+++ b/Multiplatform/Localizable.xcstrings
@@ -931,6 +931,122 @@
         }
       }
     },
+    "login.quickconnect.code.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Quick Connect code:"
+          }
+        }
+      }
+    },
+    "login.quickconnect.copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Code"
+          }
+        }
+      }
+    },
+    "login.quickconnect.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter this code on a supported Jellyfin client to login on this client without needing to enter your credentials. This screen will proceed automatically upon entering the code. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#using-quick-connect)"
+          }
+        }
+      }
+    },
+    "login.quickconnect.error" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong during Quick Connect. Please try again."
+          }
+        }
+      }
+    },
+    "login.quickconnect.preparing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing Quick Connect"
+          }
+        }
+      }
+    },
+    "login.quickconnect.success" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logged In! Please wait a moment…"
+          }
+        }
+      }
+    },
+    "login.quickconnect.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Connect"
+          }
+        }
+      }
+    },
+    "login.quickconnect.unavailable.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Jellyfin instance either does not support, or has disabled, the Quick Connect feature. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#enabling-quick-connect)"
+          }
+        }
+      }
+    },
+    "login.quickconnect.unavailable.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Connect Unavailable"
+          }
+        }
+      }
+    },
+    "login.quickconnect.waiting" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for login..."
+          }
+        }
+      }
+    },
+    "login.quickconnect.welcome.button.text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Successfully logged in. Welcome to AmpFin."
+          }
+        }
+      }
+    },
     "login.server" : {
       "localizations" : {
         "de" : {

--- a/Multiplatform/Localizable.xcstrings
+++ b/Multiplatform/Localizable.xcstrings
@@ -1010,7 +1010,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Jellyfin instance either does not support, or has disabled, the Quick Connect feature. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#enabling-quick-connect)"
+            "value" : "This could be because AmpFin doesn’t support it on this Jellyfin server version, or the Jellyfin server doesn’t have it enabled. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#enabling-quick-connect)"
           }
         }
       }

--- a/Multiplatform/Localizable.xcstrings
+++ b/Multiplatform/Localizable.xcstrings
@@ -952,22 +952,22 @@
         }
       }
     },
-    "login.quickconnect.description" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter this code on a supported Jellyfin client to login on this client without needing to enter your credentials. This screen will proceed automatically upon entering the code. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#using-quick-connect)"
-          }
-        }
-      }
-    },
     "login.quickconnect.error" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Something went wrong during Quick Connect. Please try again."
+          }
+        }
+      }
+    },
+    "login.quickconnect.link" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Learn more"
           }
         }
       }
@@ -1031,7 +1031,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Waiting for login..."
+            "value" : "Waiting for authorization..."
           }
         }
       }

--- a/Multiplatform/Localizable.xcstrings
+++ b/Multiplatform/Localizable.xcstrings
@@ -942,12 +942,12 @@
         }
       }
     },
-    "login.quickconnect.copy" : {
+    "login.quickconnect.description" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Copy Code"
+            "value" : "Requires Jellyfin 10.9+"
           }
         }
       }
@@ -958,6 +958,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Something went wrong during Quick Connect. Please try again."
+          }
+        }
+      }
+    },
+    "login.quickconnect.hint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select the code below to copy"
           }
         }
       }
@@ -1010,7 +1020,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This could be because AmpFin doesn’t support it on this Jellyfin server version, or the Jellyfin server doesn’t have it enabled. [Learn more](https://jellyfin.org/docs/general/server/quick-connect/#enabling-quick-connect)"
+            "value" : "Requires Jellyfin 10.9+"
           }
         }
       }


### PR DESCRIPTION
This PR adds support for logging into AmpFin with the [Quick Connect](https://jellyfin.org/docs/general/server/quick-connect/) feature. There is still an option to use credentials (username/password), but Quick Connect is offered as an alternative.

This PR will remain a draft until the following are completed:

- [x] Approval from the developer (ex. design-wise, using different elements, etc.)
- [x] Test on different Jellyfin server versions (**Note:** AmpFin appears to be broken with version 10.6.x or lower, showing a error about the instance not being found, unrelated to this change)
- [x] Test on real hardware
- [x] Code cleanup

If there is something else I should be doing, let me know! I have also enabled **Allow edits by maintainers** on this PR, so the developer can edit the code directly on my fork if they want to.

## Videos

### Quick Connect Supported

https://github.com/user-attachments/assets/39ac06f6-0666-483e-b104-0bb2641ab32e