### PR TITLE
Fixed Track Loading Error

### DIFF
--- a/AmpFinKit/Sources/AFNetwork/Convert/Track+Convert.swift
+++ b/AmpFinKit/Sources/AFNetwork/Convert/Track+Convert.swift
@@ -10,9 +10,7 @@ import AFFoundation
 
 internal extension Track {
     convenience init?(_ from: JellyfinItem, fallbackIndex: Int = 0, coverSize: Cover.CoverSize = .normal) {
-        guard let albumId = from.AlbumId else {
-            return nil
-        }
+        let albumId = from.AlbumId ?? "None"
         
         var cover: Cover?
         

--- a/Multiplatform/Collections/Tracks/TrackCollection.swift
+++ b/Multiplatform/Collections/Tracks/TrackCollection.swift
@@ -149,7 +149,7 @@ internal extension TrackCollection {
             
             Divider()
             
-            if album == nil {
+            if track.album.id != "None" {
                 NavigationLink(value: .albumLoadDestination(albumId: track.album.id)) {
                     Label("album.view", systemImage: "square.stack")
                     


### PR DESCRIPTION
When uploading just the audio file to JellyFin as "Song", it doesn't have a albumID. I redid the logic where when the albumId is nil it would just return "None" instead of nil to fix the Track Loading Error. This fixes this issue #79 