### PR TITLE
Add opus remux for jellyfin 10.10 and customizable bluetooth device icons

### DIFF
--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient+FeatureFlags.swift
@@ -46,6 +46,9 @@ public extension JellyfinClient {
         }
         
         switch featureFlag {
+            case .audioRemuxing:
+                // Required 10.10+
+                return serverVersion.major >= 10 && serverVersion.minor >= 10;
             case .sharedPlaylists, .lyrics:
                 // Required 10.9+
                 return serverVersion.major >= 10 && serverVersion.minor >= 9
@@ -59,7 +62,8 @@ public extension JellyfinClient {
         case lyrics
         case sharedPlaylists
         case quickConnect
-        
+        case audioRemuxing
+
         public var id: Self {
             self
         }

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient.swift
@@ -76,6 +76,14 @@ public extension JellyfinClient {
             _userId ?? ""
         }
     }
+
+    var supportsAudioRemuxing: Bool {
+        get {
+            let (major, minor, _) = serverVersion ?? (0,0,0);
+
+            return major >= 10 && minor >= 10;
+        }
+    }
 }
 
 public extension JellyfinClient {

--- a/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient.swift
+++ b/AmpFinKit/Sources/AFNetwork/HTTP/JellyfinClient.swift
@@ -76,14 +76,6 @@ public extension JellyfinClient {
             _userId ?? ""
         }
     }
-
-    var supportsAudioRemuxing: Bool {
-        get {
-            let (major, minor, _) = serverVersion ?? (0,0,0);
-
-            return major >= 10 && minor >= 10;
-        }
-    }
 }
 
 public extension JellyfinClient {

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -12,11 +12,15 @@ import AFNetwork
 
 extension DownloadManager {
     func download(trackId: String) -> URLSessionDownloadTask {
+        var supportedAudioCodecs = "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif";
+        if JellyfinClient.shared.supportsAudioRemuxing {
+            supportedAudioCodecs.append(",mp4|opus")
+        }
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: trackId).appending(path: "universal").appending(queryItems: [
             URLQueryItem(name: "apiKey", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
-            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif"),
+            URLQueryItem(name: "container", value: supportedAudioCodecs),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),
             URLQueryItem(name: "transcodingContainer", value: "m4a"),

--- a/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
+++ b/AmpFinKit/Sources/AFOffline/Filesystem/DownloadManager+Track.swift
@@ -13,7 +13,7 @@ import AFNetwork
 extension DownloadManager {
     func download(trackId: String) -> URLSessionDownloadTask {
         var supportedAudioCodecs = "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aif";
-        if JellyfinClient.shared.supportsAudioRemuxing {
+        if JellyfinClient.shared.supports(.audioRemuxing) {
             supportedAudioCodecs.append(",mp4|opus")
         }
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: trackId).appending(path: "universal").appending(queryItems: [

--- a/AmpFinKit/Sources/AFPlayback/AudioPlayer/AudioPlayer.swift
+++ b/AmpFinKit/Sources/AFPlayback/AudioPlayer/AudioPlayer.swift
@@ -8,6 +8,7 @@
 import Foundation
 import MediaPlayer
 import OSLog
+import Defaults
 import AFFoundation
 import AFExtension
 import AFNetwork
@@ -148,7 +149,7 @@ public extension AudioPlayer {
             case .HDMI, .displayPort:
                 return "tv"
             case .bluetoothLE, .bluetoothHFP, .bluetoothA2DP:
-                return UserDefaults.standard.string(forKey: "defaultBTDeviceIcon") ?? "hifispeaker"
+                return Defaults[.defaultBTDeviceIcon]
             case .headphones:
                 return "headphones"
             default:

--- a/AmpFinKit/Sources/AFPlayback/AudioPlayer/AudioPlayer.swift
+++ b/AmpFinKit/Sources/AFPlayback/AudioPlayer/AudioPlayer.swift
@@ -148,7 +148,7 @@ public extension AudioPlayer {
             case .HDMI, .displayPort:
                 return "tv"
             case .bluetoothLE, .bluetoothHFP, .bluetoothA2DP:
-                return "hifispeaker"
+                return UserDefaults.standard.string(forKey: "defaultBTDeviceIcon") ?? "hifispeaker"
             case .headphones:
                 return "headphones"
             default:

--- a/AmpFinKit/Sources/AFPlayback/Extensions/Default+Keys.swift
+++ b/AmpFinKit/Sources/AFPlayback/Extensions/Default+Keys.swift
@@ -15,4 +15,5 @@ extension Defaults.Keys {
     static let maxDownloadBitrate = Key("bitrate_downloads", default: -1)
     static let maxStreamingBitrate = Key("bitrate_streaming", default: -1)
     static let maxConstrainedBitrate = Key("bitrate_constrained", default: -1)
+    static let defaultBTDeviceIcon = Key<String>("defaultBTDeviceIcon", default: "hifispeaker")
 }

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
@@ -25,7 +25,7 @@ internal extension LocalAudioEndpoint {
         }
         #endif
         var supportedAudioCodecs = "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif";
-        if JellyfinClient.shared.supportsAudioRemuxing {
+        if JellyfinClient.shared.supports(.audioRemuxing) {
             supportedAudioCodecs.append(",mp4|opus")
         }
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: track.id).appending(path: "universal").appending(queryItems: [

--- a/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
+++ b/AmpFinKit/Sources/AFPlayback/LocalAudioEndpoint/LocalAudioEndpoint+Helper.swift
@@ -24,12 +24,15 @@ internal extension LocalAudioEndpoint {
             return AVPlayerItem(url: DownloadManager.shared.url(trackId: track.id))
         }
         #endif
-        
+        var supportedAudioCodecs = "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif";
+        if JellyfinClient.shared.supportsAudioRemuxing {
+            supportedAudioCodecs.append(",mp4|opus")
+        }
         var url = JellyfinClient.shared.serverUrl.appending(path: "Audio").appending(path: track.id).appending(path: "universal").appending(queryItems: [
             URLQueryItem(name: "apiKey", value: JellyfinClient.shared.token),
             URLQueryItem(name: "deviceId", value: JellyfinClient.shared.clientId),
             URLQueryItem(name: "userId", value: JellyfinClient.shared.userId),
-            URLQueryItem(name: "container", value: "mp3,aac,m4a|aac,m4b|aac,flac,alac,m4a|alac,m4b|alac,webma,webm|webma,wav,aiff,aiff|aif"),
+            URLQueryItem(name: "container", value: supportedAudioCodecs),
             URLQueryItem(name: "playSessionId", value: JellyfinClient.sessionID(itemId: track.id, bitrate: maxBitrate)),
             URLQueryItem(name: "startTimeTicks", value: "0"),
             URLQueryItem(name: "audioCodec", value: "aac"),

--- a/Multiplatform/Settings.bundle/Root.plist
+++ b/Multiplatform/Settings.bundle/Root.plist
@@ -48,6 +48,32 @@
 		</dict>
 		<dict>
 			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Default Bluetooth device icon</string>
+			<key>Key</key>
+			<string>defaultBTDeviceIcon</string>
+			<key>DefaultValue</key>
+			<string>hifispeaker</string>
+			<key>Values</key>
+			<array>
+				<string>hifispeaker</string>
+				<string>headphones</string>
+				<string>airpods.gen3</string>
+				<string>airpods.pro</string>
+				<string>airpods.max</string>
+			</array>
+			<key>Titles</key>
+			<array>
+				<string>Speaker</string>
+				<string>Headphones</string>
+				<string>AirPods</string>
+				<string>AirPods Pro</string>
+				<string>AirPods Max</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>Audio-Quality</string>


### PR DESCRIPTION
Jellyfin 10.10 introduces remux support for UniversalAudioController, allowing direct copy of the codec without transcoding. This feature is particularly useful for us as the iOS native player can play Opus audio, just not within the Ogg container. This PR adds an opus in mp4 profile when the server version is 10.10 or higher enables the server to directly copy opus during HLS streaming. For downloads, the server will provide an MP4 file with Opus directly copied in the container. I have tested and verified that both streaming and downloads works with all the iOS versions we support (iOS 17 and above).

This also adds a new option that enables users to customize the default Bluetooth device icon rather than to always use the hifi speaker icon. I hope Apple provides an easier way to at least identify their own headphones. The AirPods allow users to rename them, making it impossible to simply add overrides with the route name, as we currently do for some Bluetooth headphones. 